### PR TITLE
docs(vkdr): Sync documentation from vkdr source

### DIFF
--- a/vkdr/basic-commands/infra.md
+++ b/vkdr/basic-commands/infra.md
@@ -15,7 +15,7 @@ Start the local `vkdr` cluster with configurable options. The cluster is a singl
 This command also starts a pass-through local registry on port 6000. All image pulls from the cluster are redirected to this local registry transparently, helping avoid Docker Hub rate limits.
 
 ```bash
-vkdr infra start [-hV] [--silent] [--traefik] [--agents=<k3d_agents>] \
+vkdr infra start [--traefik] [--agents=<k3d_agents>] \
   [--http=<http_port>] [--https=<https_port>] [-k=<api_port>] \
   [--nodeport-base=<nodeport_base>] [--nodeports=<nodeports>] [-v=<volumes>]
 ```
@@ -73,7 +73,7 @@ vkdr infra start --traefik --agents 2
 Shortcut for `vkdr infra start` with all defaults. Starts the cluster without an ingress controller.
 
 ```bash
-vkdr infra up [-hV] [--silent]
+vkdr infra up
 ```
 
 ### Example
@@ -88,7 +88,7 @@ vkdr infra up
 Stop the local `vkdr` cluster with options.
 
 ```bash
-vkdr infra stop [-hV] [--registry] [--silent]
+vkdr infra stop [--registry]
 ```
 
 ### Flags
@@ -116,7 +116,7 @@ vkdr infra stop --registry
 Shortcut for `vkdr infra stop` with all defaults.
 
 ```bash
-vkdr infra down [-hV] [--silent]
+vkdr infra down
 ```
 
 ### Example
@@ -130,7 +130,7 @@ vkdr infra down
 Expose the local `vkdr` cluster admin port to the internet using a public Cloudflare tunnel.
 
 ```bash
-vkdr infra expose [-hV] [--off] [--silent]
+vkdr infra expose [--off]
 ```
 
 ### Flags
@@ -154,16 +154,14 @@ Stop the tunnel:
 vkdr infra expose --off
 ```
 
-:::warning
-Exposing your cluster to the internet has security implications. This is useful for testing remote access, but be aware of the risks. The tunnel provides a public URL to your cluster's Kubernetes API.
-:::
+**Warning:** Exposing your cluster to the internet has security implications. This is useful for testing remote access, but be aware of the risks. The tunnel provides a public URL to your cluster's Kubernetes API.
 
 ## vkdr infra createToken
 
 Create a service account token for accessing the cluster.
 
 ```bash
-vkdr infra createToken [-hV] [--json] [--silent] [--duration=<duration>]
+vkdr infra createToken [--json] [--duration=<duration>]
 ```
 
 ### Flags
@@ -198,7 +196,7 @@ vkdr infra createToken --json --duration 24h
 Get the CA (Certificate Authority) data from the vkdr cluster.
 
 ```bash
-vkdr infra getca [-hV] [--json] [--silent]
+vkdr infra getca [--json]
 ```
 
 ### Flags

--- a/vkdr/database-commands/postgres.md
+++ b/vkdr/database-commands/postgres.md
@@ -13,7 +13,7 @@ Use these commands to manage a PostgreSQL database in your `vkdr` cluster.
 Install a PostgreSQL database in your cluster.
 
 ```bash
-vkdr postgres install [-hVw] [--silent] [-p=<admin_password>]
+vkdr postgres install [-w] [-p=<admin_password>]
 ```
 
 ### Flags
@@ -43,7 +43,7 @@ vkdr postgres install -p mypassword -w
 Remove PostgreSQL from your cluster.
 
 ```bash
-vkdr postgres remove [-dhV] [--silent]
+vkdr postgres remove [-d]
 ```
 
 ### Flags
@@ -71,7 +71,7 @@ vkdr postgres remove -d
 Create a new database with an optional user/password as its owner.
 
 ```bash
-vkdr postgres createdb [-hsV] [--drop] [--silent] [--vault] \
+vkdr postgres createdb [-s] [--drop] [--vault] \
   [-a=<admin_password>] -d=<database_name> \
   [-p=<password>] [-u=<user_name>] \
   [--vault-rotation=<vault_rotation_schedule>]
@@ -115,7 +115,7 @@ vkdr postgres createdb -d myapp -u myuser --vault
 Drop a database and its associated secrets in Kubernetes.
 
 ```bash
-vkdr postgres dropdb [-hV] [--silent] -d=<database_name> [-u=<user_name>]
+vkdr postgres dropdb  -d=<database_name> [-u=<user_name>]
 ```
 
 ### Flags
@@ -144,7 +144,7 @@ vkdr postgres dropdb -d myapp -u myuser
 List all databases managed by the PostgreSQL cluster.
 
 ```bash
-vkdr postgres listdbs [-hV] [--json] [--silent]
+vkdr postgres listdbs [--json]
 ```
 
 ### Flags
@@ -172,7 +172,7 @@ vkdr postgres listdbs --json
 Test database connectivity by running a simple SELECT query.
 
 ```bash
-vkdr postgres pingdb [-hV] [--silent] -d=<database_name> -u=<user_name>
+vkdr postgres pingdb  -d=<database_name> -u=<user_name>
 ```
 
 ### Flags
@@ -193,12 +193,6 @@ vkdr postgres pingdb -d myapp -u myuser
 ## vkdr postgres explain
 
 Explain PostgreSQL install formulas and configuration options.
-
-```bash
-vkdr postgres explain [-hV] [--silent]
-```
-
-### Example
 
 ```bash
 vkdr postgres explain
@@ -230,8 +224,6 @@ vkdr postgres remove -d
 ```
 
 ## Formula Examples
-
-The following examples are from `vkdr postgres explain`.
 
 ### Install Postgres with admin password
 

--- a/vkdr/devportal-commands/devportal.md
+++ b/vkdr/devportal-commands/devportal.md
@@ -8,16 +8,14 @@ title: devportal
 
 Use these commands to install and manage VeeCode DevPortal, a ready-to-use Backstage distribution.
 
-:::note
-DevPortal currently requires Kong Gateway as the ingress controller.
-:::
+**Note:** DevPortal currently requires Kong Gateway as the ingress controller.
 
 ## vkdr devportal install
 
 Install VeeCode DevPortal in your cluster.
 
 ```bash
-vkdr devportal install [-hsV] [--load-env] [--samples] [--silent] \
+vkdr devportal install [-s] [--load-env] [--samples] \
   [-d=<domain>] [--profile=<profile>] [--location=<location>] \
   [--merge=<mergeValues>] [--npm=<npmRegistry>] \
   [--github-org=<github_org>] [--github-token=<github_token>] \
@@ -146,7 +144,7 @@ vkdr devportal install \
 Remove VeeCode DevPortal from your cluster.
 
 ```bash
-vkdr devportal remove [-hV] [--silent]
+vkdr devportal remove
 ```
 
 ### Example
@@ -158,12 +156,6 @@ vkdr devportal remove
 ## vkdr devportal explain
 
 Explain VeeCode DevPortal formulas and configuration options.
-
-```bash
-vkdr devportal explain [-hV] [--silent]
-```
-
-### Example
 
 ```bash
 vkdr devportal explain
@@ -246,8 +238,6 @@ curl -I https://github.com/myorg/catalog/blob/main/catalog-info.yaml
 ```
 
 ## Formula Examples
-
-The following examples are from `vkdr devportal explain`.
 
 ### Pre-requisites
 

--- a/vkdr/ingress-commands/kong.md
+++ b/vkdr/ingress-commands/kong.md
@@ -15,7 +15,7 @@ Kong Gateway is a powerful API gateway that can be used as an ingress controller
 Install Kong Gateway in your cluster.
 
 ```bash
-vkdr kong install [-ehsV] [--acme] [--api] [--default-ic] [--oidc] [--silent] \
+vkdr kong install [-es] [--acme] [--api] [--default-ic] [--oidc] \
   [--use-nodeport] [--acme-server=<acme_server>] [-d=<domain>] \
   [-i=<image_name>] [-l=<license>] [--log-level=<log_level>] \
   [-m=<kong_mode>] [-p=<admin_password>] [--proxy-tls-secret=<proxy_tls_secret>] \
@@ -119,7 +119,7 @@ vkdr kong install --default-ic \
 Remove Kong Gateway from your cluster.
 
 ```bash
-vkdr kong remove [-hV] [--silent]
+vkdr kong remove
 ```
 
 ### Example
@@ -131,12 +131,6 @@ vkdr kong remove
 ## vkdr kong explain
 
 Explain Kong install formulas and configuration options.
-
-```bash
-vkdr kong explain [-hV] [--silent]
-```
-
-### Example
 
 ```bash
 vkdr kong explain
@@ -215,8 +209,6 @@ vkdr kong install -m standard --default-ic
 ```
 
 ## Formula Examples
-
-The following examples are from `vkdr kong explain` and show common installation patterns.
 
 ### Kong OSS in db-less mode
 

--- a/vkdr/ingress-commands/nginx.md
+++ b/vkdr/ingress-commands/nginx.md
@@ -15,7 +15,7 @@ NGinx is a widely-used, high-performance ingress controller that's simple to con
 Install NGinx ingress controller in your cluster.
 
 ```bash
-vkdr nginx install [-hV] [--default-ic] [--silent] [--node-ports=<node_ports>]
+vkdr nginx install [--default-ic] [--node-ports=<node_ports>]
 ```
 
 ### Flags
@@ -66,13 +66,21 @@ vkdr nginx install --default-ic --node-ports '*'
 Remove NGinx ingress controller from your cluster.
 
 ```bash
-vkdr nginx remove [-hV] [--silent]
+vkdr nginx remove
 ```
 
 ### Example
 
 ```bash
 vkdr nginx remove
+```
+
+## vkdr nginx explain
+
+Explain NGinx ingress controller setup and configuration options.
+
+```bash
+vkdr nginx explain
 ```
 
 ## Complete Examples

--- a/vkdr/ingress-commands/traefik.md
+++ b/vkdr/ingress-commands/traefik.md
@@ -15,7 +15,7 @@ Traefik is a modern HTTP reverse proxy and load balancer that makes deploying mi
 Install Traefik ingress controller in your cluster.
 
 ```bash
-vkdr traefik install [-hsV] [--default-ic] [--silent] [-d=<domain>] \
+vkdr traefik install [-s] [--default-ic] [-d=<domain>] \
   [--node-ports=<node_ports>]
 ```
 
@@ -76,7 +76,7 @@ vkdr traefik install --node-ports '*' --default-ic
 Remove Traefik from your cluster.
 
 ```bash
-vkdr traefik remove [-hV] [--silent]
+vkdr traefik remove
 ```
 
 ### Example
@@ -88,12 +88,6 @@ vkdr traefik remove
 ## vkdr traefik explain
 
 Explain Traefik ingress controller setup and configuration options.
-
-```bash
-vkdr traefik explain [-hV] [--silent]
-```
-
-### Example
 
 ```bash
 vkdr traefik explain
@@ -177,11 +171,7 @@ curl http://whoami.localhost
 - VeeCode DevPortal (requires Kong)
 - Enterprise features needed
 
-## Formula Examples
-
-The following examples are from `vkdr traefik explain`.
-
-### Differences from Bundled Traefik
+## Differences from Bundled Traefik
 
 When you run `vkdr infra start --traefik`, k3d includes a basic Traefik instance. The standalone Traefik installed by `vkdr traefik install`:
 - Uses the official Traefik Helm chart

--- a/vkdr/ingress-commands/whoami.md
+++ b/vkdr/ingress-commands/whoami.md
@@ -15,7 +15,7 @@ The whoami service is a simple HTTP server that returns information about the re
 Install the whoami test service in your cluster.
 
 ```bash
-vkdr whoami install [-hsV] [--silent] [-d=<domain>] [--label=<String=String>]...
+vkdr whoami install [-s] [-d=<domain>] [--label=<String=String>]...
 ```
 
 ### Flags
@@ -64,13 +64,21 @@ vkdr whoami install --label app=test --label version=v1
 Remove the whoami service from your cluster.
 
 ```bash
-vkdr whoami remove [-hV] [--silent]
+vkdr whoami remove
 ```
 
 ### Example
 
 ```bash
 vkdr whoami remove
+```
+
+## vkdr whoami explain
+
+Explain whoami service setup and configuration options.
+
+```bash
+vkdr whoami explain
 ```
 
 ## Complete Examples
@@ -140,3 +148,14 @@ This information helps verify:
 - Which pod is handling the request (Hostname)
 - Request headers are being passed correctly
 - Ingress proxy headers are set properly
+
+## Resources Created
+
+- **Namespace**: `vkdr`
+- **Deployment**: `whoami` (1 replica)
+- **Service**: `whoami` (ClusterIP, port 80)
+- **Ingress**: `whoami` (with configured host)
+
+## Helm Chart
+
+Uses the [cowboysysop/whoami](https://github.com/cowboysysop/charts/tree/master/charts/whoami) Helm chart.

--- a/vkdr/monitoring-commands/_category_.json
+++ b/vkdr/monitoring-commands/_category_.json
@@ -1,0 +1,4 @@
+{
+    "label": "Monitoring Commands",
+    "position": 6
+  }

--- a/vkdr/monitoring-commands/grafana-cloud.md
+++ b/vkdr/monitoring-commands/grafana-cloud.md
@@ -1,0 +1,15 @@
+---
+sidebar_position: 2
+sidebar_label: grafana-cloud
+title: grafana-cloud
+---
+
+# Grafana Cloud
+
+Documentation coming soon.
+
+## Commands
+
+- `vkdr grafana-cloud install` - Install Grafana Cloud integration
+- `vkdr grafana-cloud remove` - Remove Grafana Cloud integration
+- `vkdr grafana-cloud explain` - Show this documentation

--- a/vkdr/monitoring-commands/overview.md
+++ b/vkdr/monitoring-commands/overview.md
@@ -1,0 +1,9 @@
+---
+sidebar_position: 1
+sidebar_label: Overview
+title: Monitoring Commands
+---
+
+# Monitoring Commands
+
+This section contains documentation for VKDR monitoring commands.

--- a/vkdr/tools-commands/eso.md
+++ b/vkdr/tools-commands/eso.md
@@ -15,7 +15,7 @@ External Secrets Operator synchronizes secrets from external secret management s
 Install External Secrets Operator in your cluster.
 
 ```bash
-vkdr eso install [-hV] [--silent]
+vkdr eso install
 ```
 
 ### Example
@@ -30,13 +30,21 @@ vkdr eso install
 Remove External Secrets Operator from your cluster.
 
 ```bash
-vkdr eso remove [-hV] [--silent]
+vkdr eso remove
 ```
 
 ### Example
 
 ```bash
 vkdr eso remove
+```
+
+## vkdr eso explain
+
+Explain External Secrets Operator setup and configuration options.
+
+```bash
+vkdr eso explain
 ```
 
 ## Complete Examples
@@ -141,7 +149,7 @@ vkdr postgres createdb -d myapp -u myuser --vault
 ```
 ┌─────────────────┐     ┌─────────────────┐     ┌─────────────────┐
 │  External       │     │  External       │     │  Kubernetes     │
-│  Secret Store   │────▶│  Secrets        │────▶│  Secret         │
+│  Secret Store   │────>│  Secrets        │────>│  Secret         │
 │  (Vault, AWS)   │     │  Operator       │     │                 │
 └─────────────────┘     └─────────────────┘     └─────────────────┘
 ```

--- a/vkdr/tools-commands/keycloak.md
+++ b/vkdr/tools-commands/keycloak.md
@@ -13,7 +13,7 @@ Use these commands to manage Keycloak identity and access management in your `vk
 Install Keycloak in your cluster.
 
 ```bash
-vkdr keycloak install [-hsV] [--silent] [-d=<domain>] \
+vkdr keycloak install [-s] [-d=<domain>] \
   [-p=<admin_password>] [-u=<admin_user>]
 ```
 
@@ -54,7 +54,7 @@ vkdr keycloak install -u myadmin -p mysecretpassword
 Remove Keycloak from your cluster.
 
 ```bash
-vkdr keycloak remove [-hV] [--silent]
+vkdr keycloak remove
 ```
 
 ### Example
@@ -68,7 +68,7 @@ vkdr keycloak remove
 Export a Keycloak realm configuration to a file.
 
 ```bash
-vkdr keycloak export [-hV] [--silent] [-a=<admin_password>] \
+vkdr keycloak export  [-a=<admin_password>] \
   [-f=<export_file>] [-r=<realm_name>]
 ```
 
@@ -99,7 +99,7 @@ vkdr keycloak export -a adminpassword -r vkdr -f vkdr-realm.json
 Import a Keycloak realm configuration from a file.
 
 ```bash
-vkdr keycloak import [-hV] [--silent] [-a=<admin_password>] \
+vkdr keycloak import  [-a=<admin_password>] \
   [-f=<import_file>]
 ```
 
@@ -122,6 +122,14 @@ Import with admin password:
 
 ```bash
 vkdr keycloak import -a adminpassword -f my-realm.json
+```
+
+## vkdr keycloak explain
+
+Explain Keycloak formulas and configuration options.
+
+```bash
+vkdr keycloak explain
 ```
 
 ## Complete Example
@@ -164,8 +172,6 @@ vkdr keycloak install
 ```
 
 ## Formula Examples
-
-The following examples are from `vkdr keycloak explain`.
 
 ### Basic Installation
 

--- a/vkdr/tools-commands/mirror.md
+++ b/vkdr/tools-commands/mirror.md
@@ -15,7 +15,7 @@ Container image mirrors help avoid rate limits from public registries like Docke
 List all configured container image mirrors.
 
 ```bash
-vkdr mirror list [-hV] [--silent]
+vkdr mirror list
 ```
 
 ### Example
@@ -29,7 +29,7 @@ vkdr mirror list
 Add a container image mirror for a specific registry.
 
 ```bash
-vkdr mirror add [-hV] [--silent] --host=<host>
+vkdr mirror add --host=<host>
 ```
 
 ### Flags
@@ -63,7 +63,7 @@ vkdr mirror add --host quay.io
 Remove a container image mirror.
 
 ```bash
-vkdr mirror remove [-hV] [--silent] --host=<host>
+vkdr mirror remove --host=<host>
 ```
 
 ### Flags
@@ -81,12 +81,6 @@ vkdr mirror remove --host docker.io
 ## vkdr mirror explain
 
 Explain mirror configuration and usage.
-
-```bash
-vkdr mirror explain [-hV] [--silent]
-```
-
-### Example
 
 ```bash
 vkdr mirror explain
@@ -134,11 +128,11 @@ kubectl run nginx --image=nginx:latest
 ```
 ┌─────────────────┐     ┌─────────────────┐     ┌─────────────────┐
 │  Pod requests   │     │  Local Mirror   │     │  Remote         │
-│  image from     │────▶│  Registry       │────▶│  Registry       │
+│  image from     │────>│  Registry       │────>│  Registry       │
 │  docker.io      │     │  (port 6000)    │     │  (docker.io)    │
 └─────────────────┘     └─────────────────┘     └─────────────────┘
                               │
-                              ▼
+                              v
                         ┌─────────────┐
                         │  Local      │
                         │  Cache      │
@@ -170,11 +164,7 @@ You can mirror any container registry:
 - **Reliability**: Local cache works even if remote registry is slow/down
 - **Air-gapped environments**: Pre-populate cache for offline use
 
-## Formula Examples
-
-The following examples are from `vkdr mirror explain`.
-
-### Configuration File
+## Configuration File
 
 The mirror configuration is stored at:
 ```
@@ -197,7 +187,7 @@ mirrors:
 
 Port numbers are automatically incremented for each new endpoint, starting from 6000.
 
-### Important Notes
+## Important Notes
 
 - Mirrors are started during `vkdr infra start` (or `vkdr infra up`)
 - You need to restart the cluster after adding a new mirror

--- a/vkdr/tools-commands/openldap.md
+++ b/vkdr/tools-commands/openldap.md
@@ -15,7 +15,7 @@ OpenLDAP provides a directory service for user authentication and authorization.
 Install OpenLDAP in your cluster.
 
 ```bash
-vkdr openldap install [-hsV] [--ldap-admin] [--silent] [--ssp] \
+vkdr openldap install [-s] [--ldap-admin] [--ssp] \
   [-d=<domain>] [--nodePort=<nodePort>] [-p=<admin_password>] [-u=<admin_user>]
 ```
 
@@ -76,7 +76,7 @@ vkdr openldap install -d example.com -s --ldap-admin --ssp
 Remove OpenLDAP from your cluster.
 
 ```bash
-vkdr openldap remove [-dhV] [--silent]
+vkdr openldap remove [-d]
 ```
 
 ### Flags
@@ -97,6 +97,14 @@ Remove OpenLDAP and delete all data:
 
 ```bash
 vkdr openldap remove -d
+```
+
+## vkdr openldap explain
+
+Explain OpenLDAP setup and configuration options.
+
+```bash
+vkdr openldap explain
 ```
 
 ## Complete Examples

--- a/vkdr/tools-commands/vault.md
+++ b/vkdr/tools-commands/vault.md
@@ -13,7 +13,7 @@ Use these commands to manage HashiCorp Vault for secrets management in your `vkd
 Install HashiCorp Vault in your cluster.
 
 ```bash
-vkdr vault install [-hsV] [--dev] [--silent] [--tls] [-d=<domain>] \
+vkdr vault install [-s] [--dev] [--tls] [-d=<domain>] \
   [--dev-root-token=<dev_root_token>]
 ```
 
@@ -64,7 +64,7 @@ vkdr vault install --tls
 Remove Vault from your cluster.
 
 ```bash
-vkdr vault remove [-hV] [--silent]
+vkdr vault remove
 ```
 
 ### Example
@@ -78,7 +78,7 @@ vkdr vault remove
 Initialize and unseal HashiCorp Vault. Required after installing Vault in production mode.
 
 ```bash
-vkdr vault init [-hV] [--silent]
+vkdr vault init
 ```
 
 ### Example
@@ -89,16 +89,14 @@ vkdr vault install
 vkdr vault init
 ```
 
-:::note
-In development mode (`--dev`), Vault is automatically initialized and unsealed. The `init` command is only needed for production mode installations.
-:::
+**Note:** In development mode (`--dev`), Vault is automatically initialized and unsealed. The `init` command is only needed for production mode installations.
 
 ## vkdr vault generate-tls
 
 Generate TLS certificates for Vault.
 
 ```bash
-vkdr vault generate-tls [-hV] [--force] [--save] [--silent] \
+vkdr vault generate-tls [--force] [--save] \
   [--cn=<commonName>] [--days=<validityDays>]
 ```
 
@@ -140,12 +138,6 @@ vkdr vault generate-tls --force --save
 ## vkdr vault explain
 
 Explain Vault install formulas and configuration options.
-
-```bash
-vkdr vault explain [-hV] [--silent]
-```
-
-### Example
 
 ```bash
 vkdr vault explain
@@ -213,8 +205,6 @@ vkdr postgres createdb -d myapp -u myuser --vault
 ```
 
 ## Formula Examples
-
-The following examples are from `vkdr vault explain`.
 
 ### Install Vault in Dev Mode
 


### PR DESCRIPTION
## Summary

This PR syncs VKDR CLI documentation from the source `docs.md` files in the vkdr repository.

### Changes

- Sync 12 command docs from `vkdr/src/main/resources/formulas/<cmd>/_meta/docs.md`
- Add new **monitoring-commands** category with grafana-cloud
- Add Docusaurus frontmatter to all synced files

### Commands Synced (13 total)

| Category | Commands |
|----------|----------|
| basic | infra |
| database | postgres |
| devportal | devportal |
| ingress | kong, traefik, nginx, whoami |
| tools | vault, keycloak, mirror, eso, openldap |
| monitoring | grafana-cloud (new) |

### Source of Truth

Documentation is now sourced from: `vkdr/src/main/resources/formulas/<command>/_meta/docs.md`

### Preview

Documentation preview: https://docs-next.platform.vee.codes/vkdr

### Checklist

- [x] Documentation synced from vkdr source
- [x] Frontmatter added for Docusaurus
- [x] New monitoring-commands category created with `_category_.json`
- [x] Preview reviewed