### PR TITLE
test(docs): docs-vs-source accuracy checks (invariant guard + drift detector)

### DIFF
--- a/devportal/plugins/adding.md
+++ b/devportal/plugins/adding.md
@@ -93,7 +93,7 @@ If you are using VKDR to manage your local DevPortal instance, add plugins using
 ```bash
 vkdr devportal install \
   --github-token=$GITHUB_TOKEN \
-  --install-samples \
+  --samples \
   --merge ./my-plugins.yaml
 ```
 


### PR DESCRIPTION
## Why

Manual verification of every factual claim in the docs is infeasible. This adds **automated checks that the docs don't drift from the product source** (`devportal-distro` / `devportal-base`) — directly motivated by the bugs found in the accuracy overhaul (#14).

These check **machine-extractable facts**, not prose. Prose still needs human/source review.

## Two layers

**Layer 1 — invariant guard (PR-blocking)** · `scripts/check-docs-invariants.mjs` · `.github/workflows/docs-invariants.yml`
Deterministic, no network. Fails a PR if a known-wrong token reappears: `veecode/devportal-bundle`, `AUTH_GITHUB_CLIENT_ID`, `GITLAB_CLIENT_ID`, `devportal-admin`/`devportal-user`, `instanceKey`, `--install-samples`, `grafana/unified-thematic-label`, and folder-index `/x/x` 404 links (the `<Card link>` class the Docusaurus build does **not** validate). Escape hatch: `<!-- docs-invariant-ignore: reason -->`.

**Layer 2 — source-drift detector (scheduled + on-demand)** · `scripts/check-source-drift.mjs` · `.github/workflows/docs-source-drift.yml`
Clones the source repos and checks the docs still agree:
- all 7 shipped profiles (from `entrypoint.sh`) are documented;
- every `GITHUB_*/GITLAB_*/AZURE_*/KEYCLOAK_*/LDAP_*` env token in the docs is actually read by a source config/entrypoint (catches typos/stale vars like the `AUTH_GITHUB_*` bug);
- bundled plugin packages (from `dynamic-plugins.default.yaml`) are documented (warn);
- RBAC roles (from `rbac-policy*.csv`) are documented.
Not PR-blocking (source moves independently); runs weekly + `workflow_dispatch`, opens/updates an issue on drift.

## Found a real bug

The guard surfaced `plugins/adding.md` using the wrong vkdr flag `--install-samples` → fixed to `--samples`.

## Verified locally

- `yarn docs:invariants` → ✓ (88 files, 10 deny rules).
- `DISTRO_PATH=… BASE_PATH=… yarn docs:drift` → ✓ no drift (7 profiles, 67 env vars, 33 bundled pkgs, 3 roles). The env-var check demonstrably flags real tokens (validated before tuning the allowlist of legitimate external/optional-feature vars).

See `scripts/README.md` for tuning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)