### PR TITLE
docs(devportal): prose-accuracy fixes (behavioral audit round 2)

### DIFF
--- a/devportal/customization/theme-hack.md
+++ b/devportal/customization/theme-hack.md
@@ -14,7 +14,7 @@ A more obscure way to override theme settings despite the chosen variant is to u
 
 ## How it works
 
-At runtime the theme is defined by an internal JSON file at `/opt/app-root/src/packages/app/dist/theme.json`. We allow overring it completely or partially by using the `global.theme` values for the Helm chart:
+At runtime the theme is defined by an internal JSON file at `/app/packages/app/dist/theme.json`. We allow overriding it completely or partially by using the `global.theme` values for the Helm chart:
 
 ```yaml
 global:

--- a/devportal/installation-guide/production-setup/setup.md
+++ b/devportal/installation-guide/production-setup/setup.md
@@ -146,7 +146,7 @@ upstream:
             port: 5432
             database: platform_devportal
             user: <db-user>
-            password: <db-password>
+            password: ${POSTGRES_PASSWORD} # injected from the devportal-secrets Secret — do not inline a real password in values.yaml
       integrations:
         github:
           - host: github.com
@@ -202,7 +202,7 @@ upstream:
             port: 5432
             database: platform_devportal
             user: <db-user>
-            password: <db-password>
+            password: ${POSTGRES_PASSWORD} # injected from the devportal-secrets Secret — do not inline a real password in values.yaml
       integrations:
         gitlab:
           - host: gitlab.com    # or your self-hosted hostname
@@ -249,7 +249,7 @@ helm upgrade --install veecode-devportal \
 Once the rollout completes, open `https://devportal.example.com` in your browser. You should reach the DevPortal login screen.
 
 ```bash
-kubectl rollout status deployment/veecode-devportal -n platform
+kubectl rollout status deployment/veecode-devportal-backstage -n platform
 ```
 
 ---

--- a/devportal/integrations/GitHub/github-integrations.md
+++ b/devportal/integrations/GitHub/github-integrations.md
@@ -83,7 +83,7 @@ To create a GitHub App for backend integrations:
 3. Fill in the application details:
    - **GitHub App name**: VeeCode DevPortal Integration
    - **Homepage URL**: `https://your-veecode-instance.com`
-   - **Authorization callback URL**: `https://your-veecode-instance.com/api/auth/github/handler/frame`
+   - **Authorization callback URL**: `https://your-veecode-instance.com/api/auth/github/handler/frame` — only required if this same GitHub App also handles sign-in. For an integration-only App (the recommended setup, where an OAuth App handles sign-in), this can be left blank.
    - **Permissions** (read more at [Required GitHub App Permissions](./github-integrations.md#required-github-app-permissions)):
      - Repository Permissions
         - Actions: Read and Write

--- a/devportal/plugins/adding.md
+++ b/devportal/plugins/adding.md
@@ -19,8 +19,8 @@ The in-portal Marketplace is the simplest path — no YAML editing required.
 1. Open your Backstage instance and click **Marketplace** in the sidebar
 2. Search for the plugin you want (e.g., GitLab, Tech Insights, AWS ECS)
 3. Click **Enable** on the plugin card
-4. A *Restart Pending* badge appears in the customer portal
-5. In the customer portal, click **Restart** — allow ~2 minutes for the pod to come back up
+4. A *Restart Pending* badge appears in the DevPortal header
+5. Restart the instance so the change takes effect — on self-hosted deployments restart the pod/container yourself (e.g. `kubectl rollout restart`); on the VeeCode SaaS the customer portal exposes a **Restart** button. Allow ~2 minutes for the instance to come back up.
 6. The plugin appears in its configured location (sidebar entry, entity tab, etc.)
 
 :::warning
@@ -123,7 +123,7 @@ Add the plugin to the `global.dynamic.plugins` array in your `values.yaml`:
 global:
   dynamic:
     plugins:
-      - package: 'oci://quay.io/veecode/gitlab:bs_1.49.4!immobiliarelabs-backstage-plugin-gitlab'
+      - package: 'oci://quay.io/veecode/gitlab:bs_1.48.4!immobiliarelabs-backstage-plugin-gitlab'
         disabled: false
         pluginConfig: {}
 ```

--- a/devportal/plugins/bundled/homepage.md
+++ b/devportal/plugins/bundled/homepage.md
@@ -36,4 +36,8 @@ pluginConfig:
         dynamicRoutes:
           - path: /
             importName: VeecodeHomepagePage
+            config:
+              props:
+                width: 1500
+                height: 800
 ```

--- a/devportal/plugins/development/wiring.md
+++ b/devportal/plugins/development/wiring.md
@@ -111,7 +111,7 @@ vkdr devportal install --github-token $GITHUB_TOKEN \
 ```
 
 :::note
-This command installs DebPortal with the extra plugin wiring. It also installs a few sample apps and configures DevPortal to rely on Verdaccio as an external npm registry.
+This command installs DevPortal with the extra plugin wiring. It also installs a few sample apps and configures DevPortal to rely on Verdaccio as an external npm registry.
 :::
 
 ### Open DevPortal (VKDR)

--- a/devportal/rbac/permissions.md
+++ b/devportal/rbac/permissions.md
@@ -32,7 +32,7 @@ Each permission in the RBAC system is structured as follows:
 
 | Name | Policy | Description | Requirements |
 | --- | --- | --- | --- |
-| scaffolder.action.execute | - | Allows execution of an action from a template | scaffolder.template.parameter.read, scaffolder.template.step.read |
+| scaffolder.action.execute | use | Allows execution of an action from a template | scaffolder.template.parameter.read, scaffolder.template.step.read |
 | scaffolder.template.parameter.read | read | Allows reading parameters of a template | scaffolder.template.step.read |
 | scaffolder.template.step.read | read | Allows reading steps of a template | scaffolder.template.parameter.read |
 | scaffolder.task.read | read | Allows reading scaffolder tasks | X |
@@ -56,6 +56,10 @@ Each permission in the RBAC system is structured as follows:
 ---
 
 ## **4. Platform Permissions**
+
+:::note
+These permissions are defined by optional add-on plugins (Kong, cluster explorer, API management, CI/CD, etc.). They are only enforced when the corresponding plugin is installed and enabled — they are **not** part of the default `rbac-policy.csv` shipped with the base image. Use them only if you have the relevant plugin enabled.
+:::
 
 | Name | Policy | Description | Requirements |
 | --- | --- | --- | --- |


### PR DESCRIPTION
## Why

A second audit — this time **prose/behavioral**, not token-based — re-read the refactored docs and checked that what is *written* matches how the product actually behaves (verified against `devportal-distro` / `devportal-base`). This is the AI-judge equivalent of the manual audit, run over our own output. 7 files fixed.

## Confirmed inaccuracies fixed

- **theme-hack.md** — theme file path was `/opt/app-root/src/packages/app/dist/theme.json`; the entrypoint actually uses `/app/packages/app/dist/theme.json` (`entrypoint.sh:8,19,23,26`). Also fixed an `overring` typo.
- **rbac/permissions.md** — `scaffolder.action.execute` policy shown as `-`; the CSV grants it with policy `use` (`rbac-policy.csv:14,39`). Added a caveat that the **Platform Permissions** table lists optional add-on-plugin permissions that are *not* in the default policy (only `kong.*` is sourced; the rest require their plugin).
- **plugins/adding.md** — gitlab OCI example used `bs_1.49.4` while the table, `GitLabPipelines.md`, `cicd.md`, and the page's own prose all say `bs_1.48.4`; aligned to `bs_1.48.4`. Reframed the Marketplace **Restart** steps so self-hosted users aren't told to use the SaaS "customer portal".
- **production-setup/setup.md** — primary values.yaml inlined `password: <db-password>`, contradicting `plan.md` ("don't commit DB passwords"); now sourced from the Secret. Fixed the rollout target to `veecode-devportal-backstage` (the backstage subchart deployment).
- **integrations/GitHub/github-integrations.md** — the GitHub App "Authorization callback URL" is only needed if that App also handles sign-in; clarified an integration-only App can leave it blank.
- **plugins/bundled/homepage.md** — mount snippet claimed to be "from dynamic-plugins.default.yaml" but omitted the `config.props` block; added it to match source exactly.
- **development/wiring.md** — `DebPortal` typo.

## Notes
- The agent also flagged the gitlab `rules: [Group, User]` block, but that is faithful to the shipped `app-config.gitlab.yaml:55-56` (provider-scoped), so it was **not** changed.
- The `global.dynamic.includes` Helm key flagged as "suspect" is **real** (present in the `next-charts` `values.yaml`), so it was left as-is.

## Verified
`yarn build` with `onBrokenLinks: throw` passes (reverted before commit); only the pre-existing `admin-ui` broken anchor remains (out of scope).

🤖 Generated with [Claude Code](https://claude.com/claude-code)