### PR TITLE
release: devportal docs accuracy overhaul → production

### DIFF
--- a/devportal/concepts/API Catalog/Howto-catalog.md
+++ b/devportal/concepts/API Catalog/Howto-catalog.md
@@ -4,36 +4,40 @@ sidebar_label: API Catalog
 title: How to Use the API Catalog
 ---
 
-Follow this step-by-step guide to effectively utilize the **API Catalog** and streamline your API integration processes.
+Follow this step-by-step guide to effectively utilize the **API Catalog** and streamline your API discovery and integration processes.
 
 ---
 
 ## **Step-by-Step Instructions**
 
 1. **Access the API Catalog**
+
+    Click on the **"Catalog"** tab in the sidebar, then filter by **Kind: API** to display only API entities.
+
 2. **Explore or Search for APIs:**
     
-    Browse the available APIs or use the search bar to find specific ones.
+    Browse the available APIs or use the search bar to find specific ones by name, owner, or tag.
     
 3. **Review the Documentation:**
     
-    Examine the API details, including:
+    Select an API to open its entity page. Examine the API spec details, including:
     
     - Available endpoints;
     - Expected parameters and responses;
     - Authentication requirements;
-    - Code examples and tutorials, if available.
-4. **Test in the Sandbox Environment:**
+    - Code examples and tutorials, if available via TechDocs.
+
+4. **Review API Metadata:**
     
-    Leverage the sandbox to validate API functionality before deploying to production.
+    Check the entity's metadata for ownership, system membership, related components, and lifecycle status. Use this to understand the API's maturity and who to contact for support.
     
-5. **Monitor Versions:**
+5. **Check Related Entities:**
     
-    Check the version history to understand updates, bug fixes, and new features.
+    Use the **Relations** panel to navigate to the system, components, or resources that depend on or provide this API.
     
 6. **Seek Support When Needed:**
     
-    If you encounter issues or have questions, contact the support team for assistance.
+    If you encounter issues or have questions, contact the API owner listed in the entity page, or reach out to the DevPortal support team.
     
 
 ---
@@ -43,3 +47,4 @@ Follow this step-by-step guide to effectively utilize the **API Catalog** and st
 - **Stay Organized:** Bookmark frequently used APIs for quick access.
 - **Document Your Integrations:** Keep records of best practices and lessons learned for future reference.
 - **Keep Up-to-Date:** Regularly review the catalog for new APIs or updates to existing ones.
+- **Register Your APIs:** If your team owns an API, register it in the catalog by adding a `catalog-info.yaml` with `kind: API` and the appropriate `spec.definition`. See the [Catalog concepts page](../catalog.md) for supported spec formats.

--- a/devportal/concepts/API Catalog/api-catalog.md
+++ b/devportal/concepts/API Catalog/api-catalog.md
@@ -3,33 +3,37 @@ sidebar_position: 1
 sidebar_label: API Catalog
 title: API Catalog
 ---
-The **API Catalog** is designed to enhance resource sharing, simplify API management, and support development across teams. It centralizes API discovery, documentation, version control, testing, and access management, helping to streamline workflows and improve productivity.
+The **API Catalog** is the section of the Software Catalog that surfaces API entities — registered API definitions that teams can discover, browse, and document centrally. It enhances resource sharing and simplifies API governance across teams.
 
 ---
 
-## Key Features and Setup  
+## Key Features
 
 1. **API Discovery**
-    - The **API Catalog** offers centralized access to organizational APIs, complete with search and filter tools to quickly locate specific APIs.
-    - APIs are categorized and tagged for easy navigation.
+    - The **API Catalog** offers centralized access to organizational APIs, with search and filter tools to quickly locate specific APIs.
+    - APIs are categorized by kind, owner, system, and tags for easy navigation.
+
 2. **Comprehensive Documentation**
-    - Detailed documentation is provided for each API, including endpoints, parameters, response formats, and authentication requirements.
-    - Additionally, code samples and tutorials may be available to support developers.
-3. **Versioning and History**
-    - Each API in the catalog supports multiple versions, so updates can be made without disrupting existing setups.
-    - A version history helps track changes and bug fixes, enabling smooth transitions and updates.
-4. **Testing and Sandbox**
-    - The Catalog includes a **sandbox environment**, allowing developers to test and validate APIs before live deployment.
-    - This ensures stability and reduces potential issues in production environments.
-5. **Access Management and Security**
-    - Access permissions can be configured for each API, controlling user roles and visibility.
-    - Authorization and authentication settings ensure that only authorized personnel can access or interact with the APIs.
+    - Detailed documentation is rendered from the API spec file for each API entity, including endpoints, parameters, response formats, and authentication requirements.
+    - Additionally, code samples and tutorials may be available if included in linked TechDocs.
+
+3. **Multiple Spec Formats**
+    - The catalog supports **OpenAPI**, **AsyncAPI**, **GraphQL**, and **gRPC** spec formats.
+    - You can register multiple API entities (one per version) if you need to maintain multiple versions in the catalog simultaneously. The platform does not manage versioning automatically.
+
+4. **Documentation-Only Viewing**
+    - The API catalog is a documentation and discovery layer. It renders spec content for reference — it does not provide a built-in sandbox or live "try it out" execution environment.
+    - To test API endpoints, use your external tooling (Postman, curl, etc.) against the actual service.
+
+5. **Access Control via RBAC**
+    - Catalog RBAC controls who can *view* API entities in the portal. Assign the `catalog.entity.read` permission to the appropriate roles.
+    - The portal does not act as an API gateway and does not enforce authentication on the APIs themselves.
 
 ---
 
 ## Why Use the API Catalog?
 
-- **Promotes Reuse**: The catalog helps developers discover existing resources, reducing the need to recreate functionalities and ensuring consistency across applications.
-- **Facilitates Collaboration**: With shared documentation, teams can easily access and utilize APIs, leading to better communication and resource-sharing.
-- **Increases Productivity**: Detailed documentation and search capabilities enable faster information retrieval, accelerating development timelines.
-- **Improves Quality**: The sandbox environment allows for testing before deployment, helping identify issues early and ensuring a stable production environment.
+- **Promotes Reuse**: Developers can discover existing APIs, reducing duplication and ensuring consistency across applications.
+- **Facilitates Collaboration**: Shared documentation lets teams access and understand APIs without contacting the owning team directly.
+- **Increases Productivity**: Spec rendering and search capabilities enable faster onboarding and integration.
+- **Improves Governance**: Centralized registration makes it easy to audit which APIs exist, who owns them, and what state they are in.

--- a/devportal/concepts/catalog.md
+++ b/devportal/concepts/catalog.md
@@ -4,13 +4,45 @@ sidebar_label: Catalog
 title: Catalog
 ---
 
-Our API Catalog is your centralized hub for browsing and searching APIs, software templates, and components generated from these templates. This guide will help you navigate the catalog effectively and make the most of its features. Below are the main topics covered in this guide:
+The **Software Catalog** is the central hub of DevPortal — a registry of all software components, APIs, infrastructure resources, systems, groups, and users in your organization. It is built on Backstage's catalog model and covers all entity kinds that Backstage supports.
+
+---
+
+## **Entity Kinds**
+
+The catalog tracks the following entity kinds (configured in `catalog.rules`):
+
+| Kind | Description |
+| --- | --- |
+| **Component** | A software component: service, website, library, etc. |
+| **API** | An API definition (OpenAPI, AsyncAPI, GraphQL, gRPC) |
+| **Resource** | Infrastructure resources: databases, clusters, environments, etc. |
+| **System** | A collection of related components and resources |
+| **Template** | A scaffolder template for creating new components |
+| **Group** | An organizational unit or team |
+| **User** | An individual user |
+| **Location** | A pointer to external catalog definition files |
+
+All entities are described in `catalog-info.yaml` files and registered via the catalog import flow or auto-discovery.
+
+---
+
+## **API Specification Formats**
+
+When viewing an API entity, the catalog renders its spec for documentation. Supported spec types include:
+
+- **OpenAPI** (REST APIs — Swagger/OpenAPI 2 or 3)
+- **AsyncAPI** (event-driven/message-based APIs)
+- **GraphQL** (GraphQL schema definitions)
+- **gRPC** (Protobuf-based APIs)
+
+Each API entity displays its endpoints, request/response schemas, and authentication details as defined in the spec file. The catalog does not provide a live "try it out" sandbox — it is a documentation and discovery layer.
 
 ---
 
 ## **Navigating the Catalog**
 
-To access the catalog, click on the **"Catalog"** tab in the navigation bar. You can use filters to refine your search by name or category for APIs, templates, or components. Once you select an item, a brief description will be displayed.
+To access the catalog, click on the **"Catalog"** tab in the navigation bar. You can use filters to refine your search by name, kind, owner, or tags. Once you select an item, a brief description will be displayed.
 
 ---
 
@@ -18,45 +50,50 @@ To access the catalog, click on the **"Catalog"** tab in the navigation bar. You
 
 Selecting an API from the catalog provides a detailed overview, including:
 
-- All endpoints, with request and response parameters.
-- Related database structures.Our platform utilizes **OpenAPI specification files** to ensure the documentation is always up-to-date.
+- Endpoints, request and response parameters (from the spec file).
+- Authentication requirements.
+- Spec format (OpenAPI, AsyncAPI, gRPC, etc.).
 
+The catalog supports **OpenAPI, AsyncAPI, GraphQL, and gRPC** specification formats. Documentation is always derived from the registered spec file.
 
 ### **Viewing Templates**
 
-When you select a template from the catalog, you’ll see all the components generated from it. Each component has a dedicated overview page, which includes its documentation for further insights.
-
+Selecting a Template entity in the catalog shows the template's description, metadata, and links to the scaffolder wizard. To create a component from it, click **"Choose"** to launch the scaffolder. See [Software Templates](./software-template.md) for details.
 
 ### **Viewing Components**
 
 Choosing a component from the catalog displays an overview that includes:
 
-- Its source code.
-- Any associated plugins.You can easily customize these plugins to align with your specific business requirements using our platform.
+- Its source code repository.
+- Any associated plugins configured via catalog annotations.
+- Links to related entities (owner, system, dependencies).
 
+### **Viewing Resources**
+
+Resources represent infrastructure entities such as clusters, databases, and environments. DevPortal uses the `Resource` kind for environments and clusters in the [Environment/Cluster journey](./environment-cluster-journey-veecode-platform.md).
+
+---
 
 ### **Accessing Documentation**
 
-One standout feature of our API Catalog is the ability to access documentation directly within the platform.
+For components with TechDocs configured, a **"Documentation"** tab is available directly on the entity page, eliminating the need to switch between tools.
 
-- Select an API, template, or component.
-- Click on the **"Documentation"** button to view all relevant details for that item.This eliminates the need to switch between multiple tabs or tools, streamlining your workflow.
+---
 
+### **Registering Existing Components**
 
-### **Tips for Maximizing the API Catalog**
+To add a pre-existing component to the catalog:
 
-- Use **filters** to quickly locate the items you need.
-- For APIs, pay close attention to endpoints and request/response parameters.
-- Leverage **OpenAPI specification files** to ensure you’re working with the latest documentation.
-- When exploring templates, review the components they generate for better context.
-- Take note of plugins associated with components and consider customizing them to fit your needs.
-- Use the **"Documentation"** button to easily access all information in one place.
+1. Click **"Register an Existing Component"** on the Create page.
+2. Provide the URL of your repository.
+3. Link to an entity file such as `catalog-info.yaml`. The wizard will:
+   - Analyze the file for entities.
+   - Add valid entities to the DevPortal catalog.
+   - Suggest a Pull Request for repositories missing the required configuration.
 
 ---
 
 ## **Get Started with a Video Tutorial**
-
-To help you get up to speed, we've included a video tutorial that demonstrates how to navigate the catalog and view components. Click on the video below to watch and learn!
 
 <center>
 <iframe  src="https://www.youtube.com/embed/IlRLyzTO0sY" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>

--- a/devportal/concepts/configuration-hierarchy.md
+++ b/devportal/concepts/configuration-hierarchy.md
@@ -17,9 +17,9 @@ DevPortal uses a 7-layer configuration merge system. Each layer overrides values
 2. app-config.production.yaml               (production overrides, shipped in the image)
 3. app-config.<profile>.yaml               (auth/identity provider config, loaded when VEECODE_PROFILE is set)
 4. app-config.distro.yaml                  (distro-level additions: marketplace, extra plugins, etc.)
-5. app-config.local.yaml                   (your operator overrides — via VEECODE_APP_CONFIG or manual mount)
+5. app-config.local.yaml                   (your operator overrides — mounted into the container)
 6. dynamic-plugins-root/app-config.dynamic-plugins.yaml  (generated at startup from your dynamic-plugins.yaml)
-7. app-config.saas.yaml                    (SaaS/platform-managed overrides — last wins)
+7. app-config.saas.yaml                    (SaaS/platform-managed overrides — last wins; populated from VEECODE_APP_CONFIG)
 ```
 
 Layer 7 wins. Layer 1 provides the baseline.
@@ -71,7 +71,11 @@ organization:
   name: My Org
 ```
 
-Pass it to the container via the `VEECODE_APP_CONFIG` environment variable (path to the file) or by mounting it into the container.
+Mount it into the container at `/app/app-config.local.yaml` (for example, a Docker volume mount or a Kubernetes ConfigMap).
+
+:::note `VEECODE_APP_CONFIG` is different
+`VEECODE_APP_CONFIG` is **not** a path to `app-config.local.yaml`. It holds a **base64-encoded app-config document** that the entrypoint decodes into `app-config.saas.yaml` (layer 7, loaded last). It is used by the VeeCode SaaS platform; self-hosted operators normally mount `app-config.local.yaml` instead.
+:::
 
 ---
 
@@ -104,7 +108,7 @@ organization:
 ```
 
 2. For Helm: place these keys under `upstream.backstage.appConfig` in `values.yaml`.
-3. For Docker: mount the file and set `VEECODE_APP_CONFIG=/path/to/app-config.local.yaml`.
+3. For Docker: mount the file into the container at `/app/app-config.local.yaml`.
 
 ---
 

--- a/devportal/concepts/configuration-hierarchy.md
+++ b/devportal/concepts/configuration-hierarchy.md
@@ -1,0 +1,119 @@
+---
+sidebar_position: 8
+sidebar_label: Configuration Hierarchy
+title: Configuration Hierarchy
+---
+
+# Configuration Hierarchy
+
+DevPortal uses a 7-layer configuration merge system. Each layer overrides values from the layers below it. Understanding this order is essential for diagnosing unexpected behavior and knowing where to put your custom settings.
+
+---
+
+## The 7 Layers (lowest to highest priority)
+
+```
+1. app-config.yaml                          (base defaults, shipped in the image)
+2. app-config.production.yaml               (production overrides, shipped in the image)
+3. app-config.<profile>.yaml               (auth/identity provider config, loaded when VEECODE_PROFILE is set)
+4. app-config.distro.yaml                  (distro-level additions: marketplace, extra plugins, etc.)
+5. app-config.local.yaml                   (your operator overrides — via VEECODE_APP_CONFIG or manual mount)
+6. dynamic-plugins-root/app-config.dynamic-plugins.yaml  (generated at startup from your dynamic-plugins.yaml)
+7. app-config.saas.yaml                    (SaaS/platform-managed overrides — last wins)
+```
+
+Layer 7 wins. Layer 1 provides the baseline.
+
+---
+
+## When to Use Each Layer
+
+| Layer | Who controls it | What to put there |
+| --- | --- | --- |
+| `app-config.yaml` | Distro (read-only) | Base catalog rules, auth skeleton, RBAC defaults |
+| `app-config.production.yaml` | Distro (read-only) | Production DB, TechDocs publisher, backend URLs |
+| `app-config.<profile>.yaml` | Distro + distro profiles | Auth provider config for your chosen provider |
+| `app-config.distro.yaml` | Distro (read-only) | Extensions marketplace, `pluginsWithPermission`, distro branding tweaks |
+| `app-config.local.yaml` | **You (operator)** | Your `app.branding`, `organization.name`, custom catalog locations, overrides |
+| `app-config.dynamic-plugins.yaml` | Generated at startup | Plugin-specific config injected by enabled plugins |
+| `app-config.saas.yaml` | VeeCode SaaS (if using managed offering) | Platform-level enforced settings |
+
+**Your primary customization target is `app-config.local.yaml`** (or the equivalent `upstream.backstage.appConfig` in Helm values).
+
+---
+
+## Helm vs. Docker Config Paths
+
+### Helm chart
+In the Helm chart, your operator config lives under `upstream.backstage.appConfig` in `values.yaml`:
+
+```yaml
+upstream:
+  backstage:
+    appConfig:
+      app:
+        branding:
+          fullLogo: https://example.com/logo.svg
+      organization:
+        name: My Org
+```
+
+This maps to the `app-config.local.yaml` layer at runtime.
+
+### Docker / distro direct
+For Docker or direct distro deployments, write your overrides in `app-config.local.yaml` at the repo root (top-level keys, no Helm wrapper):
+
+```yaml
+app:
+  branding:
+    fullLogo: https://example.com/logo.svg
+organization:
+  name: My Org
+```
+
+Pass it to the container via the `VEECODE_APP_CONFIG` environment variable (path to the file) or by mounting it into the container.
+
+---
+
+## Practical Example
+
+To set a custom organization name and branding without touching the distro files:
+
+1. Create (or update) your `app-config.local.yaml`:
+
+```yaml
+app:
+  title: Acme Developer Portal
+  branding:
+    fullLogo: https://cdn.acme.com/portal-logo.svg
+    iconLogo: https://cdn.acme.com/portal-icon.png
+    fullLogoWidth: 160
+    theme:
+      light:
+        variant: "backstage"
+        palette:
+          navigation:
+            background: "#1a1a2e"
+      dark:
+        variant: "backstage"
+        palette:
+          navigation:
+            background: "#1a1a2e"
+organization:
+  name: Acme Corp
+```
+
+2. For Helm: place these keys under `upstream.backstage.appConfig` in `values.yaml`.
+3. For Docker: mount the file and set `VEECODE_APP_CONFIG=/path/to/app-config.local.yaml`.
+
+---
+
+## Debugging Config
+
+If a setting is not taking effect, check:
+1. Which layer is setting the conflicting value.
+2. Whether a higher-priority layer is overriding it.
+3. Whether the key path is correct (e.g., `app.branding.theme.light.palette.*`, not `branding.theme.light.primaryColor`).
+
+For branding-specific keys, see [Simple Branding](../customization/branding.md).  
+For profile-specific env vars, see [Configuration Profiles](./configuration-profiles.md).

--- a/devportal/concepts/configuration-profiles.md
+++ b/devportal/concepts/configuration-profiles.md
@@ -53,13 +53,13 @@ This profile does **not** enable OAuth sign-in. Users authenticate as guest or v
 ### `github`
 | Variable | Required | Notes |
 | --- | --- | --- |
-| `GITHUB_CLIENT_ID` | Yes | GitHub OAuth App client ID |
-| `GITHUB_CLIENT_SECRET` | Yes | GitHub OAuth App client secret |
+| `GITHUB_CLIENT_ID` | Yes | GitHub App client ID (for integrations) |
+| `GITHUB_CLIENT_SECRET` | Yes | GitHub App client secret (for integrations) |
 | `GITHUB_APP_ID` | Yes | GitHub App ID |
 | `GITHUB_PRIVATE_KEY` | Yes | GitHub App private key (YAML block scalar `\|`) |
 | `GITHUB_ORG` | Yes | GitHub organization name |
 
-The entrypoint auto-copies `GITHUB_CLIENT_ID` → `GITHUB_AUTH_CLIENT_ID` if the latter is unset.
+Sign-in uses `GITHUB_AUTH_CLIENT_ID` / `GITHUB_AUTH_CLIENT_SECRET`. If those are unset, the entrypoint auto-copies `GITHUB_CLIENT_ID` → `GITHUB_AUTH_CLIENT_ID` and `GITHUB_CLIENT_SECRET` → `GITHUB_AUTH_CLIENT_SECRET`, so a single GitHub App's OAuth credentials can serve both sign-in and integration.
 
 ### `gitlab`
 | Variable | Required | Notes |

--- a/devportal/concepts/configuration-profiles.md
+++ b/devportal/concepts/configuration-profiles.md
@@ -1,0 +1,104 @@
+---
+sidebar_position: 6
+sidebar_label: Configuration Profiles
+title: Configuration Profiles
+---
+
+# Configuration Profiles (`VEECODE_PROFILE`)
+
+DevPortal ships seven **configuration profiles**, each enabling a different authentication and identity provider. A profile is selected at startup by setting the `VEECODE_PROFILE` environment variable. The entrypoint script loads the corresponding `app-config.<profile>.yaml` on top of the base configuration.
+
+---
+
+## The 7 Profiles
+
+| Profile | Provider | Primary use case |
+| --- | --- | --- |
+| `github-pat` | GitHub (Personal Access Token) | GitHub integration without OAuth sign-in; uses `GITHUB_TOKEN` for catalog/org-sync only |
+| `github` | GitHub OAuth App | Full GitHub integration with OAuth sign-in |
+| `gitlab` | GitLab OAuth App | Full GitLab integration with OAuth sign-in |
+| `keycloak` | Keycloak | Enterprise SSO via OpenID Connect |
+| `azure` | Azure AD | Microsoft Entra ID / Azure Active Directory |
+| `ldap` | Generic LDAP | LDAP directory integration |
+| `ldap-ad` | Active Directory (LDAP) | AD-specific LDAP with `sAMAccountName` and AD object classes |
+
+---
+
+## How Profiles Are Loaded
+
+At container startup, `entrypoint.sh` reads `VEECODE_PROFILE` and passes the matching config file as an extra `--config` argument to Backstage:
+
+```
+app-config.yaml
+  → app-config.production.yaml
+    → app-config.<profile>.yaml    ← loaded here
+      → app-config.distro.yaml
+        → ...
+```
+
+See [Configuration Hierarchy](./configuration-hierarchy.md) for the full 7-layer merge order.
+
+---
+
+## Key Environment Variables per Profile
+
+### `github-pat`
+| Variable | Required | Notes |
+| --- | --- | --- |
+| `GITHUB_TOKEN` | Yes | Personal Access Token for catalog/org-sync |
+| `GITHUB_ORG` | Yes | GitHub organization name |
+
+This profile does **not** enable OAuth sign-in. Users authenticate as guest or via another mechanism.
+
+### `github`
+| Variable | Required | Notes |
+| --- | --- | --- |
+| `GITHUB_CLIENT_ID` | Yes | GitHub OAuth App client ID |
+| `GITHUB_CLIENT_SECRET` | Yes | GitHub OAuth App client secret |
+| `GITHUB_APP_ID` | Yes | GitHub App ID |
+| `GITHUB_PRIVATE_KEY` | Yes | GitHub App private key (YAML block scalar `\|`) |
+| `GITHUB_ORG` | Yes | GitHub organization name |
+
+The entrypoint auto-copies `GITHUB_CLIENT_ID` → `GITHUB_AUTH_CLIENT_ID` if the latter is unset.
+
+### `gitlab`
+| Variable | Required | Notes |
+| --- | --- | --- |
+| `GITLAB_AUTH_CLIENT_ID` | Yes | GitLab OAuth Application client ID |
+| `GITLAB_AUTH_CLIENT_SECRET` | Yes | GitLab OAuth Application client secret |
+| `GITLAB_TOKEN` | Yes | Personal/group token for catalog integration |
+| `GITLAB_HOST` | Yes | GitLab host (e.g., `gitlab.com`) |
+| `GITLAB_GROUP` | Yes | Root group for catalog discovery |
+
+### `keycloak`
+| Variable | Required | Notes |
+| --- | --- | --- |
+| `KEYCLOAK_BASE_URL` | Yes | e.g., `https://keycloak.example.com` |
+| `KEYCLOAK_CLIENT_ID` | Yes | Client ID in Keycloak |
+| `KEYCLOAK_CLIENT_SECRET` | Yes | Client secret |
+| `KEYCLOAK_REALM` | Yes | Realm name |
+| `AUTH_SESSION_SECRET` | Yes | Session encryption secret |
+
+The entrypoint derives `KEYCLOAK_METADATA_URL` from `KEYCLOAK_BASE_URL` + `KEYCLOAK_REALM` if not set explicitly.
+
+### `azure`
+| Variable | Required | Notes |
+| --- | --- | --- |
+| `AZURE_CLIENT_ID` | Yes | Azure AD app client ID |
+| `AZURE_CLIENT_SECRET` | Yes | Azure AD app client secret |
+| `AZURE_TENANT_ID` | Yes | Azure AD tenant ID |
+| `AZURE_ORGANIZATION` | Yes | Azure DevOps organization |
+| `AUTH_SESSION_SECRET` | Yes | Session encryption secret |
+
+### `ldap` / `ldap-ad`
+See `app-config.ldap.yaml` / `app-config.ldap-ad.yaml` for the full set of `LDAP_*` variables. The `ldap-ad` profile defaults `LDAP_TLS_REJECT_UNAUTHORIZED=true` and uses AD-specific object classes.
+
+---
+
+## Notes
+
+- RSA private keys (e.g., `GITHUB_PRIVATE_KEY`) **must** use a YAML block scalar (`|`) to preserve newlines. Inline strings break parsing.
+- If no profile is set, the base `app-config.yaml` guest auth is used (development only).
+- Profiles are additive — the profile config merges on top of the base; it does not replace it.
+
+For installation instructions that use these profiles, see the [installation guide](/devportal/installation-guide/simple-setup).

--- a/devportal/concepts/dynamic-plugins.md
+++ b/devportal/concepts/dynamic-plugins.md
@@ -1,0 +1,101 @@
+---
+sidebar_position: 7
+sidebar_label: Dynamic Plugins
+title: Dynamic Plugins
+---
+
+# Dynamic Plugins
+
+Dynamic plugins are the mechanism DevPortal uses to ship, enable, and configure Backstage plugins **without rebuilding the container image**. This is one of the core differentiators of the distro.
+
+---
+
+## Preinstalled vs. Downloaded Plugins
+
+DevPortal ships two categories of dynamic plugins:
+
+### Preinstalled (bundled) plugins
+These are compiled into the image at build time and live under `/app/dynamic-plugins/dist/`. They are always present but start **disabled by default** (`disabled: true`). You enable them at runtime by listing them in your `dynamic-plugins.yaml` configuration.
+
+The full list of preinstalled plugins and their default configuration is in `devportal-distro/dynamic-plugins.default.yaml`.
+
+### Downloaded (OCI/NPM) plugins
+These are not bundled in the image. They are pulled at startup from an OCI registry (`oci://...`) or an NPM registry. You add them to your `dynamic-plugins.yaml` and the runtime downloads and installs them before the app starts.
+
+---
+
+## Enabling Plugins
+
+To enable a plugin, reference it in your `dynamic-plugins.yaml`:
+
+```yaml
+plugins:
+  # Enable a preinstalled plugin (already in the image)
+  - package: ./dynamic-plugins/dist/backstage-plugin-kubernetes-dynamic
+    disabled: false
+    pluginConfig:
+      # ... plugin-specific config
+
+  # Download and enable an OCI plugin
+  - package: 'oci://quay.io/veecode/backstage:bs_1.49.4!backstage-plugin-mcp-actions-backend'
+    disabled: false
+    pluginConfig:
+      # ... plugin-specific config
+```
+
+In the Helm chart, this maps to `global.dynamic.plugins` in `values.yaml`. For Docker installs, mount the file or pass it via `VEECODE_APP_CONFIG`.
+
+---
+
+## Plugin Configuration
+
+Each plugin entry can include a `pluginConfig` block that is merged into the app configuration for that plugin. This is how entity tabs, mount points, and feature flags are configured without touching `app-config.yaml` directly.
+
+Mount points (frontend plugins) and backend plugin wiring are both declared in the plugin's own `pluginConfig`:
+
+```yaml
+pluginConfig:
+  dynamicPlugins:
+    frontend:
+      my-org.my-plugin:
+        mountPoints:
+          - mountPoint: entity.page.overview/cards
+            importName: MyEntityCard
+        dynamicRoutes:
+          - path: /my-feature
+            importName: MyFeaturePage
+```
+
+---
+
+## The Extensions Marketplace
+
+The distro includes a plugin marketplace (`devportal-marketplace-frontend-dynamic`) that allows admins to browse, enable, and disable plugins via the DevPortal UI. Marketplace access is controlled by RBAC permissions (`extensions.plugin.configuration.read/write`). See [Permissions](../rbac/permissions.md) for details.
+
+---
+
+## MCP Stack (AI-powered Actions)
+
+The distro ships an optional MCP (Model Context Protocol) stack as OCI dynamic plugins from `quay.io/veecode`:
+
+| Package | Role |
+| --- | --- |
+| `backstage-plugin-mcp-actions-backend` | Core MCP backend; aggregates tool sources |
+| `*-software-catalog-mcp-extras` | Catalog tools for MCP |
+| `*-techdocs-mcp-extras` | TechDocs tools for MCP |
+| `*-scaffolder-mcp-extras` | Scaffolder tools for MCP |
+| `*-mcp-chat-backend` + `*-mcp-chat` | In-portal AI chat at `/mcp-chat` |
+
+All must be enabled together (`disabled: false`). Supported AI providers for the chat plugin: OpenAI, Anthropic, Gemini, and Ollama.
+
+---
+
+## Key Files
+
+| File | Purpose |
+| --- | --- |
+| `dynamic-plugins.default.yaml` | All preinstalled plugins with their defaults (disabled by default) |
+| `dynamic-plugins.yaml` | Your runtime overrides — enable plugins and add OCI/NPM packages here |
+| `app-config.dynamic-plugins.yaml` | Generated at startup; merges plugin configs into the running app config |
+
+For adding plugins through the UI, see the [Adding Plugins guide](/devportal/plugins/adding).

--- a/devportal/concepts/dynamic-plugins.md
+++ b/devportal/concepts/dynamic-plugins.md
@@ -43,7 +43,7 @@ plugins:
       # ... plugin-specific config
 ```
 
-In the Helm chart, this maps to `global.dynamic.plugins` in `values.yaml`. For Docker installs, mount the file or pass it via `VEECODE_APP_CONFIG`.
+In the Helm chart, this maps to `global.dynamic.plugins` in `values.yaml`. For Docker installs, mount your `dynamic-plugins.yaml` into the container at `/app/dynamic-plugins.yaml` (the entrypoint processes it at startup). Note that `VEECODE_APP_CONFIG` only carries `app-config` content — it cannot be used to deliver `dynamic-plugins.yaml`.
 
 ---
 

--- a/devportal/concepts/environment-cluster-journey-veecode-platform.md
+++ b/devportal/concepts/environment-cluster-journey-veecode-platform.md
@@ -4,58 +4,48 @@ sidebar_label: Environment Cluster Journey by Veecode Platform
 title: Environment Cluster Journey by Veecode Platform
 ---
 
-
-Welcome to our Environment Cluster journey. In this brief guide, we will explain the purpose of our approach and provide a step-by-step guide for its use.
+Welcome to the Environment Cluster journey. This guide explains the purpose of this approach and how to use it.
 
 # Environment Cluster Journey by Veecode Platform
 
+Our environment cluster journey is designed to make the development process more dynamic and independent. Once the DevOps team has set up the environments and the types of clusters available, developers can deploy their applications swiftly and accurately.
 
-Our environment cluster journey is designed to make the development process more dynamic and independent. Once the DevOps team has set up the environments and the types of clusters available, Developers will be able to deploy their applications swiftly and accurately. This greatly contributes to best development practices and, consequently, to the creation of a more suitable environment.
+## How It Works
 
-But how is this possible?
+Both **Environments** and **Clusters** are modeled as `Resource` entities in the Software Catalog. The journey works as follows:
 
-The Environment Cluster journey functions as follows:
-<!-- O Environment nao é criado com um template nosso. Ele é manualmente inserido no catalogo atualmente. Cluster sera criado com as info previamente inseridas no environment selecionado, porem, as informacoes especificas do cluster podem  ser inseridas no proprio template (name, tamanho de maquina, regiao, repositorio...) -->
- 1. **Environment Creation:** The DevOps team establishes an “environment”, a space where specific environmental information is stored. This information contains network configurations, environmental variables, service access credentials, and more.
+1. **Environment Creation:** The DevOps team manually inserts an Environment entity into the catalog. An environment stores configuration and credential references: network settings, environmental variables, service access credentials, and more. Environments are currently registered manually via a `catalog-info.yaml` with `kind: Resource` and `spec.type: environment`.
 
- 2. **Cluster Configuration:** Within each environment, “clusters” are formed. A cluster is a collection of servers that collaborate to provide high availability and load balancing for your applications. A cluster will be created with the information previously entered in the selected environment. However, specific cluster information can be entered in the template itself (name, machine size, region, repository…).
+2. **Cluster Configuration:** A Cluster is a `Resource` entity that references an environment. Clusters are typically created via a scaffolder IaC template — the template uses the environment's configuration as input (network, region, credentials) and applies cluster-specific parameters (name, machine size, repository). Once the template runs, the cluster entity is registered in the catalog.
 
-3. **Application Deployment:** With the environments and clusters set up, developers can then proceed to deploy their applications.
+3. **Application Deployment:** With environments and clusters in the catalog, developers can reference them in software templates and deploy their applications to the correct target infrastructure.
 
-This approach enables a more dynamic and independent development process. Developers are granted greater freedom and flexibility in deploying their applications, while the DevOps team can ensure that the infrastructure is correctly configured and optimized. This greatly contributes to best development practices and the creation of a more suitable environment for your company.
+This approach creates a clear separation of concerns: the DevOps team controls environment and cluster definitions; developers consume them self-service.
 
-#### To summarize: Environments are utilized by clusters, and these clusters function as the infrastructure for the deployment of the final projects.
+**Summary:** Environments are utilized by clusters, and clusters provide the infrastructure for deploying final projects.
 
-Bellow step-by-step guide : 
-## Using Cluster templates 
-1. **Prepare your environment:** Before you start, make sure you have an environment set up.
-2. **Access Veecode Platform:** Log in to the Veecode Platform and select “Create” from the sidebar menu.
-3. **Choose to Provision EC2 Cluster:** From the options available, select “Provision EC2 Cluster”.
-4. **Select Environment:** Choose the desired Environment under “Resource Available”, then press “Next”.
-5. **Configure EC2:** Fill in all the fields in the EC2 configuration section, then press “Next”.
-6. **Network Configurations:** Enter your Network Configurations, then press “Next”.
-7. **Terraform Configuration:** In this step, you need to enter your Terraform Configuration.
-8. **Set up Git:** Select your Git provider, specify the owner, and name the repository you’re going to create. Also, set the visibility of the repository. Once done, click on “Review”.
-9. **Review and Create:** Review all the information you’ve entered for the cluster creation. Make sure everything is correct, then click on “Create”.
+---
 
-10. **Secrets Configuration:** It’s crucial to define all the necessary secrets for the functioning of the generated project so that the pipeline that will create the cluster can be executed without errors.
-Below are the secrets that you need to ensure you have for the project pipeline to function properly:
+## Using Cluster Templates
 
-🔑 **AWS_ACCESS_KEY mandatory**
-🔑 **AWS_SECRET_KEY mandatory**
-🔑 **AWS_REGION mandatory**
-🔑 INFRACOST_API_KEY optional
+The steps below describe the general flow for creating a cluster via a scaffolder template. The exact fields depend on the specific template your organization has published.
 
-:::warning
+1. **Prepare your environment:** Before you start, make sure you have an environment `Resource` entity registered in the catalog.
+2. **Access DevPortal:** Log in and select **"Create"** from the sidebar menu.
+3. **Choose a cluster template:** Select the cluster provisioning template relevant to your target infrastructure.
+4. **Select Environment:** Choose the desired environment from the available resources, then proceed.
+5. **Configure cluster parameters:** Fill in resource-specific fields (machine size, region, network settings, etc.) as required by the template.
+6. **Set up the repository:** Select your Git provider, specify the owner, and name the repository the template will create. Set repository visibility.
+7. **Review and Create:** Review all the information, then click **"Create"**.
+8. **Monitor the pipeline:** The scaffolder creates the repository and triggers a CI/CD pipeline. Monitor progress in the scaffolder log view. Ensure all required secrets (cloud credentials, tokens, etc.) are configured in your CI/CD environment before the pipeline runs.
+9. **Locate the cluster in the catalog:** Once the pipeline completes and the entity is registered, navigate to the **Catalog**, filter by `Kind: Resource`, and look for your cluster by name.
 
-  Remember, each variable plays a significant role in the project’s functionality, so make sure they are correctly set.
-
+:::info
+There is no dedicated "Resources > Clusters" sidebar entry. Clusters and environments appear in the standard Catalog view — filter by `Kind: Resource` or use the search to find them.
 :::
 
-11.    **Initiate the Pipeline:** Now, you should initiate the pipeline. This can be done through the Veecode Platform interface. In the sidebar, navigate to the “Resources” area and select “Clusters”. Then, choose the cluster with the name you provided. Click on the “About” menu and, at the bottom of the screen, click on “Deploy”. The pipeline will begin to build your cluster.
+:::warning
+Make sure all required CI/CD secrets (e.g., cloud provider credentials) are set before initiating the pipeline. Missing secrets will cause the pipeline to fail.
+:::
 
-If everything goes as expected, the pipeline will build your cluster and it will be visible for use in your projects.
-    
-Remember, each step is crucial for the successful creation of a cluster. If you encounter any issues, refer to the platform’s documentation or reach out to their support team. 
-
-    
+If you encounter any issues, refer to the platform's documentation or reach out to the support team.

--- a/devportal/concepts/iac-template.md
+++ b/devportal/concepts/iac-template.md
@@ -4,13 +4,19 @@ sidebar_label:  Infrastructure as Code (IaC) Templates
 title:  Infrastructure as Code (IaC) Templates
 ---
 
-This guide explains how to implement **Infrastructure as Code (IaC)** templates to streamline infrastructure resource management while fostering a collaborative DevOps culture.
+This guide explains how **Infrastructure as Code (IaC) templates** work in DevPortal, enabling your team to provision infrastructure through a self-service scaffolder workflow rather than running tools manually.
 
 ---
 
 ### Step 1: **Understand the Basics**
 
-IaC templates are reusable files that define the desired configuration of your infrastructure. They enable automation, consistency, and scalability in deploying infrastructure components such as servers, databases, and networks.
+IaC templates in DevPortal are scaffolder templates (like software templates) that generate infrastructure repositories — typically containing Terraform, CloudFormation, Pulumi, or similar IaC files. Provisioning happens through the CI/CD pipeline that the template wires up, not by the developer running infrastructure tools locally.
+
+The typical flow is:
+1. Developer fills in the template form (resource sizes, region, network settings, etc.).
+2. The scaffolder creates a new repository with the IaC configuration files.
+3. A CI/CD pipeline (GitHub Actions, GitLab CI, etc.) is triggered and runs the infrastructure tool (e.g., `terraform apply`).
+4. The resulting infrastructure resource is registered in the catalog as a `Resource` entity.
 
 ---
 
@@ -31,39 +37,39 @@ IaC templates are reusable files that define the desired configuration of your i
 ### Step 4: **Customize the Template**
 
 1. Read the documentation associated with the chosen template.
-2. Modify the parameters to suit your specific needs, such as:
-    - **Resource sizes:** Define CPU, memory, or storage requirements.
-    - **Network configurations:** Specify subnets, routing, and security rules.
-    - **Security settings:** Adjust permissions or encryption protocols.
+2. Fill in the form parameters, which typically include:
+    - **Resource sizes:** CPU, memory, or storage requirements.
+    - **Network configurations:** subnets, routing, and security rules.
+    - **Security settings:** permissions or encryption protocols.
+    - **Repository settings:** provider, owner, repository name, visibility.
 
 ---
 
-### Step 5: **Deploy the Template**
+### Step 5: **Create and Monitor the Pipeline**
 
-1. Use a tool like **AWS CloudFormation**, **Terraform**, or similar orchestration platforms to deploy the template.
-2. Run the deployment command from your terminal or platform interface, ensuring the execution parameters are accurate.
+1. Review all inputs on the **Overview Page** and click **"Create"**.
+2. The scaffolder creates the IaC repository and triggers the CI/CD pipeline.
+3. Monitor the creation log in the DevPortal scaffolder UI for real-time updates.
+4. Once the pipeline completes, the infrastructure resource may be registered in the catalog automatically (depending on the template) or require manual registration.
+
+:::info
+You do not need to run `terraform apply`, `aws cloudformation deploy`, or any other infrastructure CLI locally. The CI/CD pipeline configured by the template handles deployment in your target environment.
+:::
 
 ---
 
-### Step 6: **Monitor Deployment Progress**
-
-- Track the deployment process via logs or the orchestration platform's dashboard.
-- Address any errors or warnings that arise during deployment.
-
----
-
-### Step 7: **Validate the Infrastructure**
+### Step 6: **Validate the Infrastructure**
 
 - Verify that the deployed infrastructure matches your requirements.
-- Test the environment for functionality, security, and stability.
+- Test the environment for functionality, security, and stability using your standard validation tooling.
 
 ---
 
 ### Tips for Using IaC Templates
 
-- **Leverage Version Control:** Store templates in systems like Git to track changes and enable team collaboration.
-- **Promote Collaboration:** Encourage developers and operations teams to work together in defining infrastructure needs.
-- **Document Changes:** Maintain a detailed history of modifications to templates for transparency and reproducibility.
+- **Leverage Version Control:** All IaC files are stored in Git — use PRs and code review for infrastructure changes.
+- **Promote Collaboration:** Developers and operations teams co-own the generated repository.
+- **Document Changes:** The catalog entity for the resource tracks ownership and metadata; keep it updated.
 
 ---
 
@@ -71,8 +77,8 @@ IaC templates are reusable files that define the desired configuration of your i
 
 1. **Consistency:** Eliminate configuration drift by ensuring uniform deployments.
 2. **Scalability:** Easily replicate infrastructure to meet growing demands.
-3. **Collaboration:** Foster DevOps practices with shared ownership of infrastructure management.
+3. **Self-Service:** Developers can provision infrastructure without waiting for manual ops work.
 
-By adopting IaC templates, you enable your team to create, deploy, and manage infrastructure efficiently, reducing manual errors and accelerating development timelines.
+By adopting IaC templates, you enable your team to create and manage infrastructure efficiently through the portal, with CI/CD as the enforcement layer.
 
-For further assistance, refer to your platform's documentation or [contact us](https://platform.vee.codes/contact-us/).
+For further assistance, refer to your platform's documentation or [contact us](https://platform.vee.codes/support/).

--- a/devportal/concepts/software-template.md
+++ b/devportal/concepts/software-template.md
@@ -14,7 +14,7 @@ This guide provides detailed steps for leveraging the **template creation featur
 
 The **template creation feature** helps developers quickly create projects or components by providing a standardized, pre-configured base. This approach reduces the time spent on setup, allowing developers to focus on specific tasks.
 
-Templates include options for linking repositories, integrating databases, and configuring CI/CD pipelines, promoting a seamless workflow from creation to deployment.
+Templates include options for linking repositories, integrating databases, and configuring CI/CD pipelines, promoting a seamless workflow from creation to deployment. The specific form fields you see depend entirely on the template selected — each template defines its own parameters.
 
 ---
 
@@ -55,18 +55,14 @@ If you have a pre-existing component to add:
 
 ### **Configuring the Template**
 
-1. **Project Information:**
-    - Input basic details such as name, description, Java version, and application port.
-2. **Database Configuration:**
-    - Select a database and provide authentication credentials (username/password).
-    - You can skip this step if the database is unnecessary.
-3. **CI/CD Pipeline Setup:**
-    - Select a provider (e.g., GitHub), specify the repository owner, and enter repository details.
-    - Optional: Enable Kubernetes Kong export or add a mock server URL.
-4. **OpenAPI File Configuration:**
-    - Define the location of OpenAPI files (Spec House) for catalog integration.
-5. **Build Destination:**
-    - Provide the destination repository details (provider, owner, repository).
+Each template defines its own form steps and fields. Common categories of information that templates ask for include:
+
+- **Project information:** name, description, owner.
+- **Repository details:** provider (GitHub, GitLab, etc.), organization, repository name, visibility.
+- **CI/CD pipeline setup:** target branch, pipeline configuration.
+- **Database or infrastructure options:** where applicable, per-template.
+
+The exact fields depend on the template. Review the template's description and documentation before starting.
 
 ---
 

--- a/devportal/customization/_category_.json
+++ b/devportal/customization/_category_.json
@@ -1,4 +1,4 @@
 {
     "label": "Customizing DevPortal",
-    "position": 7
+    "position": 8
 }

--- a/devportal/customization/branding.md
+++ b/devportal/customization/branding.md
@@ -8,7 +8,9 @@ There is an entire branding section in the `appConfig` section of DevPortal conf
 
 ## The default config
 
-Our default values for Helm chart install are:
+The default branding values are defined in `app-config.yaml` (base layer). For a Helm install, override them under `upstream.backstage.appConfig`; for a Docker/distro install, place them at the top level in `app-config.local.yaml`.
+
+**Helm chart format:**
 
 ```yaml
 upstream:
@@ -17,24 +19,48 @@ upstream:
       app:
         branding:
           fullLogo: https://veecode-platform.github.io/support/logos/logo.svg
-          fullLogoDark: https://veecode-platform.github.io/support/logos/logo-black.svg
           iconLogo: https://veecode-platform.github.io/support/logos/logo-mobile.png
           fullLogoWidth: 150
           theme:
             light:
               variant: "backstage"
               palette:
-              navigation:
-                background: "#222222" # your fixed light theme sidebar background
+                navigation:
+                  background: "#222222"
             dark:
               variant: "backstage"
               palette:
-              navigation:
-                background: "#222222" # same fixed color for dark theme
+                navigation:
+                  background: "#222222"
       backend:
         csp:
           img-src: ["'self'","data:","https://raw.githubusercontent.com/","https://avatars.githubusercontent.com/","https://veecode-platform.github.io","https://platform.vee.codes"]
 ```
+
+**Direct app-config format (Docker/distro):**
+
+```yaml
+app:
+  branding:
+    fullLogo: https://veecode-platform.github.io/support/logos/logo.svg
+    iconLogo: https://veecode-platform.github.io/support/logos/logo-mobile.png
+    fullLogoWidth: 150
+    theme:
+      light:
+        variant: "backstage"
+        palette:
+          navigation:
+            background: "#222222"
+      dark:
+        variant: "backstage"
+        palette:
+          navigation:
+            background: "#222222"
+```
+
+:::note About `fullLogoDark`
+The `fullLogoDark` key (a separate dark-mode logo) is present in the source but is currently commented out in the default config with the note "new form breaks sidebar, check later." It is **not recommended** to use this key until it is formally supported. Use a single `fullLogo` URL that works in both themes, or style accordingly.
+:::
 
 Will result in this:
 

--- a/devportal/customization/custom-header.md
+++ b/devportal/customization/custom-header.md
@@ -4,9 +4,9 @@ sidebar_label: Custom header plugin
 title: Custom header plugin
 ---
 
-Similarly to “home” plugin customizations, the shared Backstage header can also be customized in a dynamic plugin.
+Similarly to "home" plugin customizations, the shared Backstage header can also be customized as a dynamic plugin.
 
-The source code for the current DevPortal header is at [VeeCode Homepage](https://github.com/veecode-platform/dynamic-plugins/tree/main/plugins/veecode-homepage)
+The default header ships as package `veecode-platform-plugin-veecode-global-header-dynamic` (preinstalled, enabled by default). It uses the `application/header` mount point with `position: above-main-content`, and exposes sub-mount-points for injecting custom components into the header bar (`global.header/component`, `global.header/profile`).
 
 ## Source code
 
@@ -14,4 +14,4 @@ The source code for the current DevPortal header plugin is at [VeeCode Header Pl
 
 ## RHDH Header docs
 
-The VeeCode header plugin is based on the RHDH header plugin, so you can refer to the [RHDH Header docs](https://docs.redhat.com/en/documentation/red_hat_developer_hub/1.7/html/customizing_red_hat_developer_hub/configuring-the-global-header-in-rhdh) for more information.
+The VeeCode header plugin is based on the RHDH header plugin, so you can refer to the [RHDH Header docs](https://docs.redhat.com/en/documentation/red_hat_developer_hub/1.7/html/customizing_red_hat_developer_hub/configuring-the-global-header-in-rhdh) for more information on mount points and customization patterns.

--- a/devportal/customization/custom-home.md
+++ b/devportal/customization/custom-home.md
@@ -4,13 +4,13 @@ sidebar_label: Custom home plugin
 title: Custom home plugin
 ---
 
-The entire DevPortal “home” can be replaced by your own custom dynamic plugin.
+The entire DevPortal "home" can be replaced by your own custom dynamic plugin.
 
 :::info
 Please understand this is a development effort that involves coding a custom plugin and packaging it as an NPM package.
 :::
 
-The process for creating a “plugin-home” is described in the official Backstage documentation at [Backstage homepage - Setup and Customization](https://backstage.io/docs/getting-started/homepage).
+The process for creating a "plugin-home" is described in the official Backstage documentation at [Backstage homepage - Setup and Customization](https://backstage.io/docs/getting-started/homepage).
 
 ## Dynamic config
 
@@ -31,27 +31,39 @@ dynamicPlugins:
 
 ## Branding
 
-Config elements under `appConfig` that affect the home plugin (most are branding related):
+The home plugin reads branding configuration from the standard `app.branding` keys in app-config. The correct keys are:
 
 ```yaml
-branding:
-  fullLogo: string
-  fullLogoDarkMode: string
-  theme:
-    light:
-      primaryColor: string
-      headerColor1: string
-      headerColor2: string
-      navigationIndicatorColor: string
-    dark:
-      primaryColor: string
-      headerColor1: string
-      headerColor2: string
-      navigationIndicatorColor: string
-support:
-  url: string
+app:
+  branding:
+    fullLogo: https://example.com/logo.svg       # logo URL (light mode)
+    iconLogo: https://example.com/icon.png       # small/icon logo
+    fullLogoWidth: 150
+    theme:
+      light:
+        variant: "backstage"
+        palette:
+          navigation:
+            background: "#222222"
+          primary:
+            main: "#1F5493"
+          # ... other palette keys
+        typography:
+          fontFamily: "Inter"
+      dark:
+        variant: "backstage"
+        palette:
+          navigation:
+            background: "#222222"
+          # ... other palette keys
 ```
+
+For the full list of available palette and typography keys, see [Simple Branding](./branding.md).
+
+:::note
+Keys like `primaryColor`, `headerColor1`, `headerColor2`, `navigationIndicatorColor`, and `fullLogoDarkMode` do not correspond to any supported app-config structure. Use the `app.branding.theme.{light,dark}.palette.*` keys shown above instead.
+:::
 
 ## Source code
 
-The source code for the current DevPortal home plugin is at [VeeCode Header Plugin](https://github.com/veecode-platform/devportal-plugins/tree/main/workspace/homepage)
+The source code for the current DevPortal home plugin is at [VeeCode Homepage Plugin](https://github.com/veecode-platform/devportal-plugins/tree/main/workspace/homepage)

--- a/devportal/customization/customization.md
+++ b/devportal/customization/customization.md
@@ -6,12 +6,12 @@ title: Customizing DevPortal
 
 VeeCode DevPortal follows Backstage's standards for customizing the UI and adds a few extra options:
 
-- **Simple branding:** there is an entire branding section in the `appConfig` section of DevPortal configuration (also under `values.yaml`) that lets you pick one of the pre-defined theme variants and its light/dark options, allowing you top customize every single aspect from it.
+- **Simple branding:** there is an entire branding section under `app.branding` in the app configuration that lets you pick one of the pre-defined theme variants and its light/dark options, allowing you to customize every aspect of the theme. In a Helm install this lives under `upstream.backstage.appConfig`; in a Docker/distro install it lives at the top level of `app-config.local.yaml`.
   
-- **Custom theme hacking:** a few simple properties in the `global.theme` section of the `values.yaml` file can help you hack some custom colors into whatever theme variant you are using.
+- **Custom theme hacking (legacy):** the `global.theme.customJson` Helm value allows low-level JSON overrides of the internal theme file. This is a Helm-only workaround — see [Theme hacking](./theme-hack.md) for details. For most use cases, the `app.branding.theme.*` mechanism above is sufficient and preferred.
 
-- **Custom home page plugin:** the entire home page can be customized by using the Backstage plugin system (https://backstage.io/docs/getting-started/homepage)
+- **Custom home page plugin:** the entire home page can be customized by replacing the default homepage dynamic plugin with your own. See [Custom home plugin](./custom-home.md).
 
-- **Custom header plugin:** the header shared by all pages can also be customized by using the Backstage plugin system
+- **Custom header plugin:** the header shared by all pages can also be customized as a dynamic plugin. See [Custom header plugin](./custom-header.md).
 
 Usually the branding option is all you need to customize the look and feel of your DevPortal. If you need to go beyond that, you can use the custom theme hacking option or even create a custom plugin if you are feeling brave.

--- a/devportal/customization/theme-hack.md
+++ b/devportal/customization/theme-hack.md
@@ -14,7 +14,7 @@ A more obscure way to override theme settings despite the chosen variant is to u
 
 ## How it works
 
-At runtime the theme is defined by an internal JSON file at `/opt/app-root/src/packages/app/dist/theme.json`. We allow overring it completely or partially by using the `global.theme` values for the Helm chart:
+At runtime the theme is defined by an internal JSON file at `/app/packages/app/dist/theme.json`. We allow overriding it completely or partially by using the `global.theme` values for the Helm chart:
 
 ```yaml
 global:

--- a/devportal/customization/theme-hack.md
+++ b/devportal/customization/theme-hack.md
@@ -4,7 +4,13 @@ sidebar_label: Theme hacking
 title: Theme hacking
 ---
 
-A more obscure way to override theme settings despite the chosen variant is to use the `global.theme.customJson` value to override just the ones you want to change.
+:::warning Legacy workaround
+The `global.theme.customJson` mechanism described on this page is a **Helm-only** workaround that requires setting `readOnlyRootFilesystem: false`. It is superseded by the supported `app.branding.theme.*` configuration (see [Simple Branding](./branding.md)), which works in all install methods and does not require a writable container filesystem.
+
+Use this page only if you need to override theme values that are not yet exposed by `app.branding.theme.*`, or if you are on an older install that has not migrated to the supported mechanism.
+:::
+
+A more obscure way to override theme settings despite the chosen variant is to use the `global.theme.customJson` value to override just the ones you want to change. This approach is specific to the **Helm chart install** — Docker/distro users should use `app.branding.theme.*` in `app-config.local.yaml` instead.
 
 ## How it works
 

--- a/devportal/installation-guide/FAQs.md
+++ b/devportal/installation-guide/FAQs.md
@@ -1,22 +1,134 @@
-# FAQs
+---
+sidebar_label: FAQs
+title: Frequently Asked Questions
+---
 
-# What can I do in the Demo Journey?
-In the Demo Journey, you can:
+# Frequently Asked Questions
 
-- View the structure of the template projects
-- Explore the pre-configured APIs in the Catalog
-- Explore the Tech Docs plugin
-- Configure Github integration to use the more advanced features
-- Create new projects from the software templates provided (code scaffolding)
-- Develop API projects and publish API specs on the API Catalog
+## Container startup
 
-# Why do I need to create a new Github organization?
-Creating a new Github organization is optional, but it is recommended for this demo. This is because the demo will create a number of projects and repositories, and it is easier to keep track of them if they are all in the same organization.
+### The container starts but the marketplace is empty
 
-# Why is it necessary to create a PAT token?
-A PAT token is a personal access token that allows you to grant specific permissions to other users or applications. In the context of the DevPortal, a PAT token is used to authenticate with Github and create new projects and repositories.
+The marketplace catalog is downloaded from an OCI image at startup. If the download fails (no internet access, image pull timeout, or first-boot race) the marketplace will be empty.
 
+Force a fresh download on the next startup:
 
-# Why can't I create a secret in my GitHub organization?
-You cannot create a secret in your GitHub organization if you don't have permission to do so. If you do have permission, but you still can't create a secret, check if the secret name doesn't conflict with an existing repository name, and if the secret is not too long or contains invalid characters. If you still can't create a secret, contact GitHub support for help.
+```bash
+docker run ... -e CATALOG_INDEX_REFRESH=true veecode/devportal:latest
+```
 
+The default catalog image is `quay.io/veecode/plugin-catalog-index:latest`. Override it with `CATALOG_INDEX_IMAGE` if you host it internally.
+
+### The container exits immediately after starting
+
+Check the logs:
+
+```bash
+docker logs devportal
+```
+
+Common causes:
+- A required environment variable for the selected `VEECODE_PROFILE` is missing (e.g., `GITLAB_HOST` is unset for the `gitlab` profile).
+- The `app-config.local.yaml` mount path is wrong or the file has a syntax error. Backstage will fail to start if any mounted config file is invalid YAML.
+- Port 7007 is already in use on the host.
+
+### I set a key in `app-config.local.yaml` but it has no effect
+
+Config files are merged in a 7-layer order. Your `app-config.local.yaml` is layer 5, but plugin-generated config (`dynamic-plugins-root/app-config.dynamic-plugins.yaml`) is layer 6 and loads after it. A plugin's `pluginConfig` block in `dynamic-plugins.yaml` can override keys from your `local.yaml`. See [Custom Configuration](./docker-local/custom-config) for the full merge order.
+
+---
+
+## Authentication
+
+### GitLab OAuth sign-in is not working
+
+Check that you are using the correct variable names. The GitLab profile reads `GITLAB_AUTH_CLIENT_ID` and `GITLAB_AUTH_CLIENT_SECRET`. Using `GITLAB_CLIENT_ID` or `GITLAB_CLIENT_SECRET` will not work.
+
+Also verify the redirect URI in your GitLab OAuth Application matches exactly:
+```
+http://localhost:7007/api/auth/gitlab/handler/frame
+```
+
+### GitHub sign-in fails with "Bad credentials"
+
+The `github` profile uses two separate credential sets:
+- **Sign-in (OAuth)**: `GITHUB_AUTH_CLIENT_ID` / `GITHUB_AUTH_CLIENT_SECRET`
+- **Integration (GitHub App)**: `GITHUB_CLIENT_ID` / `GITHUB_CLIENT_SECRET` + `GITHUB_APP_ID` + `GITHUB_PRIVATE_KEY`
+
+If `GITHUB_AUTH_CLIENT_ID` is unset, the entrypoint automatically copies `GITHUB_CLIENT_ID` to it. Make sure your OAuth App credentials (not GitHub App credentials) are set for sign-in.
+
+### `GITHUB_PRIVATE_KEY` causes errors due to newlines
+
+Use `GITHUB_PRIVATE_KEY_BASE64` instead. Base64-encode the PEM file and set that variable. The entrypoint decodes it automatically:
+
+```bash
+base64 -w 0 < github-app.private-key.pem
+# paste the output as GITHUB_PRIVATE_KEY_BASE64
+```
+
+### Keycloak authentication fails at sign-in
+
+Ensure `KEYCLOAK_METADATA_URL` resolves correctly. If you do not set it explicitly, the entrypoint derives it as `$KEYCLOAK_BASE_URL/realms/$KEYCLOAK_REALM`. You can verify this by checking the container log line: `VEECODE: Keycloak metadata URL: ...`.
+
+Also confirm the redirect URI in your Keycloak client:
+```
+http://localhost:7007/api/auth/oidc/handler/frame
+```
+
+---
+
+## Profiles
+
+### Which profile should I use?
+
+| Situation | Recommended profile |
+|---|---|
+| Just exploring, no auth needed | (no profile — use guest) |
+| GitHub repos, simple token access | `github-pat` |
+| GitHub repos + team sign-in | `github` |
+| GitLab repos + sign-in | `gitlab` |
+| Azure DevOps repos + sign-in | `azure` |
+| Keycloak SSO | `keycloak` |
+| OpenLDAP / FreeIPA | `ldap` |
+| Microsoft Active Directory | `ldap-ad` |
+
+### I set `VEECODE_PROFILE` but it has no effect
+
+Profile names are case-sensitive and lowercase. Supported values: `github-pat`, `github`, `gitlab`, `keycloak`, `azure`, `ldap`, `ldap-ad`. Verify the container log shows `VEECODE: Loading <profile> configuration...` during startup.
+
+---
+
+## Plugins
+
+### How do I enable a bundled plugin?
+
+Add an entry to your `dynamic-plugins.yaml` with `disabled: false`. You do not need to rebuild the image or run `yarn add`. Example:
+
+```yaml
+plugins:
+  - package: './dynamic-plugins/dist/backstage-plugin-kubernetes-dynamic'
+    disabled: false
+```
+
+See [Dynamic Plugins](./docker-local/custom-plugins) for details.
+
+### My `dynamic-plugins.yaml` disables all plugins unexpectedly
+
+If your custom `dynamic-plugins.yaml` does not include `dynamic-plugins.default.yaml`, all built-in plugins revert to their default state (disabled). Add the `includes:` key:
+
+```yaml
+includes:
+  - dynamic-plugins.default.yaml
+
+plugins:
+  - package: './dynamic-plugins/dist/my-plugin-dynamic'
+    disabled: false
+```
+
+---
+
+## Getting more help
+
+- Container logs: `docker logs devportal`
+- Project docs: [https://docs.platform.vee.codes](https://docs.platform.vee.codes)
+- GitHub issues: [veecode-platform/devportal](https://github.com/veecode-platform/devportal)

--- a/devportal/installation-guide/FAQs.md
+++ b/devportal/installation-guide/FAQs.md
@@ -68,7 +68,7 @@ base64 -w 0 < github-app.private-key.pem
 
 ### Keycloak authentication fails at sign-in
 
-Ensure `KEYCLOAK_METADATA_URL` resolves correctly. If you do not set it explicitly, the entrypoint derives it as `$KEYCLOAK_BASE_URL/realms/$KEYCLOAK_REALM`. You can verify this by checking the container log line: `VEECODE: Keycloak metadata URL: ...`.
+Confirm `KEYCLOAK_BASE_URL` and `KEYCLOAK_REALM` are correct — the discovery URL is built from them (`$KEYCLOAK_BASE_URL/realms/$KEYCLOAK_REALM`). The entrypoint logs the resolved value: check the container log line `VEECODE: Keycloak metadata URL: ...`.
 
 Also confirm the redirect URI in your Keycloak client:
 ```

--- a/devportal/installation-guide/docker-local/custom-catalog.md
+++ b/devportal/installation-guide/docker-local/custom-catalog.md
@@ -179,20 +179,32 @@ spec:
 
 ## Remote Catalog Locations
 
-You can also reference remote catalogs in your `app-config.local.yaml`:
+You can also reference remote catalogs in your `app-config.local.yaml`. The `url` type requires a fully-resolved, direct URL to a single file — glob patterns are not supported by the `url` location type:
 
 ```yaml
 catalog:
   locations:
-    # GitHub repository
+    # Single file from a GitHub repository
     - type: url
       target: https://github.com/my-org/my-repo/blob/main/catalog-info.yaml
-    
-    # Multiple files from a repo
-    - type: url
-      target: https://github.com/my-org/my-repo/blob/main/*/catalog-info.yaml
-      rules:
-        - allow: [Component, API, Resource]
+```
+
+To discover catalog files across many repositories automatically, use the GitHub or GitLab catalog provider (configured via a `VEECODE_PROFILE` or in `app-config.local.yaml`). For example, using the GitHub provider in `app-config.local.yaml`:
+
+```yaml
+catalog:
+  providers:
+    github:
+      my-org:
+        organization: my-org
+        catalogPath: /catalog-info.yaml
+        filters:
+          branch: main
+        schedule:
+          frequency:
+            minutes: 30
+          timeout:
+            minutes: 3
 ```
 
 ## Next Steps

--- a/devportal/installation-guide/docker-local/custom-config.md
+++ b/devportal/installation-guide/docker-local/custom-config.md
@@ -93,7 +93,7 @@ docker compose up -d
 
 ## Development Mode
 
-Set `DEVELOPMENT=true` to enable nodemon hot-reload. DevPortal will watch `app-config.yaml`, `app-config.production.yaml`, and `app-config.local.yaml` for changes and restart automatically:
+Set `DEVELOPMENT=true` to enable nodemon hot-reload. DevPortal will watch `app-config.yaml`, `app-config.production.yaml`, `app-config.local.yaml`, and the generated `dynamic-plugins-root/app-config.dynamic-plugins.yaml` for changes and restart automatically:
 
 ```yaml
 services:

--- a/devportal/installation-guide/docker-local/custom-config.md
+++ b/devportal/installation-guide/docker-local/custom-config.md
@@ -8,7 +8,21 @@ title: Custom App Configuration
 
 You can use a combination of `docker compose`, profiles, configuration files, and environment variables to customize the behavior of the DevPortal instance.
 
-You can customize your DevPortal by mounting a custom `app-config.local.yaml` file. This allows you to override default settings without modifying the container image.
+The recommended approach is to mount a custom `app-config.local.yaml` file. This lets you override default settings without modifying the container image.
+
+## Config File Precedence
+
+All configuration files are loaded and merged in this order (later entries override earlier ones):
+
+1. `app-config.yaml` — base image defaults
+2. `app-config.production.yaml` — production overrides baked into image
+3. `app-config.{profile}.yaml` — profile-specific config (if `VEECODE_PROFILE` is set)
+4. `app-config.distro.yaml` — distro-level overrides (baked in)
+5. **`app-config.local.yaml`** ← your custom file, mounted at `/app/app-config.local.yaml`
+6. `dynamic-plugins-root/app-config.dynamic-plugins.yaml` — generated at startup by the plugin install script
+7. `app-config.saas.yaml` — SaaS mode only; decoded from `VEECODE_APP_CONFIG`
+
+Your `app-config.local.yaml` (layer 5) wins over the base and profile defaults, but plugin-injected config (layer 6) is loaded after it. If a setting in `local.yaml` seems to be ignored, check whether an enabled plugin's `pluginConfig` block is overriding it.
 
 ## Creating a Custom Config File
 
@@ -37,7 +51,7 @@ integrations:
     - host: github.com
       token: ${GITHUB_TOKEN}
 
-# Example: Configure catalog locations
+# Example: Add a catalog location
 catalog:
   locations:
     - type: url
@@ -77,6 +91,33 @@ Then run:
 docker compose up -d
 ```
 
+## Development Mode
+
+Set `DEVELOPMENT=true` to enable nodemon hot-reload. DevPortal will watch `app-config.yaml`, `app-config.production.yaml`, and `app-config.local.yaml` for changes and restart automatically:
+
+```yaml
+services:
+  devportal:
+    image: veecode/devportal:latest
+    ports:
+      - "7007:7007"
+    environment:
+      - DEVELOPMENT=true
+    volumes:
+      - ./app-config.local.yaml:/app/app-config.local.yaml:ro
+```
+
+You can also expose the Node.js debugger by setting `DEBUG_PORT`:
+
+```yaml
+    environment:
+      - DEVELOPMENT=true
+      - DEBUG_PORT=9229
+    ports:
+      - "7007:7007"
+      - "9229:9229"
+```
+
 ## Common Configuration Examples
 
 ### GitHub Authentication
@@ -87,20 +128,8 @@ auth:
   providers:
     github:
       development:
-        clientId: ${GITHUB_CLIENT_ID}
-        clientSecret: ${GITHUB_CLIENT_SECRET}
-```
-
-### Custom Theme
-
-```yaml
-app:
-  branding:
-    theme:
-      light:
-        primaryColor: '#2196F3'
-      dark:
-        primaryColor: '#90CAF9'
+        clientId: ${GITHUB_AUTH_CLIENT_ID}
+        clientSecret: ${GITHUB_AUTH_CLIENT_SECRET}
 ```
 
 ### Database Configuration
@@ -118,7 +147,7 @@ backend:
 
 ## Environment Variables
 
-You can use environment variables in your config file using the `${VAR_NAME}` syntax. Pass them via Docker:
+You can reference environment variables in your config file using the `${VAR_NAME}` syntax. Pass them via Docker:
 
 ```bash
 docker run --rm --name devportal -d \

--- a/devportal/installation-guide/docker-local/custom-plugins.md
+++ b/devportal/installation-guide/docker-local/custom-plugins.md
@@ -83,27 +83,39 @@ plugins:
     disabled: false
 ```
 
-## Plugin Configuration Priority
+## Plugin Configuration and the `includes` Mechanism
 
-The configuration is merged in this order (later overrides earlier):
+Your `dynamic-plugins.yaml` merges with the image defaults via an `includes:` key. The distro's bundled `dynamic-plugins.yaml` already includes `dynamic-plugins.default.yaml` to preserve the image's built-in plugin set. If you mount your own `dynamic-plugins.yaml`, make sure it also includes the defaults so you do not lose the pre-installed plugins:
 
-1. `dynamic-plugins.default.yaml` (built into image)
-2. `dynamic-plugins.yaml` (your custom file)
-3. Environment variables (if applicable)
+```yaml
+includes:
+  - dynamic-plugins.default.yaml
+
+plugins:
+  # Your overrides below
+  - package: './dynamic-plugins/dist/some-plugin-dynamic'
+    disabled: false
+```
+
+The `dynamic-plugins.default.yaml` file (pre-installed plugins, all `disabled: true` by default) is baked into the image. You can also mount it from the distro repo to inspect or override individual entries.
+
+After the plugin install script runs, it generates `dynamic-plugins-root/app-config.dynamic-plugins.yaml` from the `pluginConfig` blocks of all enabled plugins. This generated file is loaded last in the config chain (after your `app-config.local.yaml`).
+
+### `extensions-install.yaml`
+
+You may notice an `extensions-install.yaml` file in the working directory. This is a write-through cache for marketplace plugin installation state — the database is the source of truth and the Node app regenerates this file on every change. The Python install script reads it at startup. Do not delete it; if it is missing, the entrypoint creates an empty one automatically.
 
 ## Important Notes
 
 Dynamic plugins are a deep subject on their own. Please refer to the [Plugins](/devportal/plugins/) section for more information. The dynamic plugins feature is based on the same plugin system used by Red Hat Developer Hub, so Red Hat documentation is also a good resource on this topic.
 
 :::warning
-Dynamic plugins require a special kind of packaging. All DevPortal pre-installled dynamic plugins are published on public NPM registry and pulled at build time into the `veecode/devportal` distro image. **Not all plugins are available as dynamic plugins**, so please check each plugin's documentation to see if it is available as such. There is usually a `-dynamic` suffix in a dynamic plugin package name, and they tend to exist in both forms in the NPM registry.
+Dynamic plugins require a special kind of packaging. All DevPortal pre-installed dynamic plugins are published on the public NPM registry and pulled at build time into the `veecode/devportal` distro image. **Not all plugins are available as dynamic plugins**, so please check each plugin's documentation to see if it is available as such. There is usually a `-dynamic` suffix in a dynamic plugin package name, and they tend to exist in both forms in the NPM registry.
 :::
 
 ## Examples
 
-We have published several dynamic plugins examples on GitHub.
-
-- [TODO](.)
+We have published several dynamic plugins examples on GitHub. Check the [OCI plugins guide](https://github.com/veecode-platform/devportal-distro/blob/main/docs/OCI_PLUGINS.md) in the distro repository for OCI registry usage examples.
 
 ## Viewing Available Plugins
 

--- a/devportal/installation-guide/docker-local/intro.md
+++ b/devportal/installation-guide/docker-local/intro.md
@@ -78,7 +78,7 @@ Points to notice:
 
 - "Guest" authentication enabled as an admin user ("user:default/admin", "group:default/admins", "role:default/admin" with all permissions granted).
 - The catalog will be populated with a built-in catalog for demo purposes (folder "/app/examples" inside the containers).
-- The bundled `app-config*.yaml` files define the container's default behavior, but you can override any config by mounting a custom config file at `/app/app-config.local.yaml` and providing just the changes you need.
+- The container loads several config files in a defined precedence order. Your custom file at `/app/app-config.local.yaml` overrides the base and profile defaults. See [Custom Configuration](./custom-config) for the full merge order.
 - There are many plugins already bundled in the container image, ready to be enabled. You can mount the `/app/dynamic-plugins.yaml` plugin file to enable those you want to use.
 
 We will talk more about these subjects later on, but understand there are many possible ways to extend and configure DevPortal container without rebuilding it (or making a derived image).

--- a/devportal/installation-guide/docker-local/profiles.md
+++ b/devportal/installation-guide/docker-local/profiles.md
@@ -6,13 +6,13 @@ title: Quick Setup with Profiles
 
 ## Using VeeCode Profiles
 
-VeeCode DevPortal supports **profiles** as a convenient way to quickly configure authentication and catalog integration for common Git providers. Instead of manually configuring `app-config.local.yaml`, you can use the `VEECODE_PROFILE` environment variable and DevPortal will merge specific config elements during start time.
+VeeCode DevPortal supports **profiles** as a convenient way to quickly configure authentication and catalog integration for common identity providers. Instead of manually configuring `app-config.local.yaml`, you can set the `VEECODE_PROFILE` environment variable and DevPortal will merge the corresponding pre-built configuration during startup.
 
 ## What are Profiles?
 
 Profiles are pre-configured setups that automatically configure:
 
-- **Authentication**: Login integration against your Git provider
+- **Authentication**: Login integration against your identity provider
 - **Catalog Integration**: Automatic discovery of repositories and catalog files
 - **Organizational Data**: Replicate your organization's users and groups structure in DevPortal
 - **Default Settings**: Sensible defaults for common use cases
@@ -21,21 +21,21 @@ A profile is activated by setting the `VEECODE_PROFILE` environment variable to 
 
 | Profile | Auth | Org Data | Discovery |
 |---------|------|----------|-----------|
-| github-pat | Guest (none) | Built-in (or from catalog) | Repos in org |
-| github  | GitHub Auth | Teams and members | Repos in org |
-| gitlab  | GitLab Auth | Groups and members | Repos in group |
-| azure   | Azure Entra | Groups and members | Repos in org/project |
-| ldap    | LDAP Auth | Users and groups | None |
+| `github-pat` | Guest (none) | Built-in (or from catalog) | Repos in org |
+| `github` | GitHub OAuth | Teams and members | Repos in org |
+| `gitlab` | GitLab OAuth | Groups and members | Repos in group |
+| `keycloak` | Keycloak OIDC | Users and groups from Keycloak | None |
+| `azure` | Azure Entra ID | Groups and members | Repos in org/project |
+| `ldap` | LDAP | Users and groups | None |
+| `ldap-ad` | LDAP (Active Directory) | Users and groups | None |
 
-These settings are somewhat opinionated to provide a good starting point. They are somewhat cumbersome to get right manually (specially on the first time), so using profiles can save time and effort.
-
-These settings can also be further customized or overridden by providing a custom `app-config.local.yaml` file if needed.
+Profile settings are opinionated starting points. They can be further customized or overridden by providing a custom `app-config.local.yaml` file.
 
 ## Available Profiles
 
 ### GitHub PAT Profile
 
-This is the simplest possible GitHub-related profile, it only requires a GitHub PAT token for repo access.
+The simplest GitHub-related profile. Requires only a GitHub PAT token for repo access. Authentication uses the "guest" mode (no sign-in required).
 
 Use the following sample `docker-compose.yml`:
 
@@ -63,9 +63,16 @@ docker compose up --no-log-prefix
 - GitHub catalog provider for automatic repository discovery
 - GitHub integration for actions, issues, pull requests, and more
 
+**Required environment variables:**
+
+- `GITHUB_TOKEN`: Personal access token (classic or fine-grained) with `repo` or `public_repo` scope
+- `GITHUB_ORG`: GitHub organization name for catalog discovery
+
 :::note
-PAT is a personal access token, you can generate one in your GitHub account settings. It is severely limited in API calls, check your logs for rate limiting errors when things break.
+A PAT is limited in API calls. Watch the container logs for rate-limiting errors. For production use, prefer the `github` profile with a GitHub App.
 :::
+
+---
 
 ### GitHub Profile
 
@@ -86,7 +93,6 @@ services:
       - GITHUB_CLIENT_ID
       - GITHUB_CLIENT_SECRET
       - GITHUB_PRIVATE_KEY
-      - GITHUB_TOKEN
 ```
 
 Then run:
@@ -103,24 +109,26 @@ docker compose up --no-log-prefix
 
 **Required environment variables:**
 
-- `GITHUB_ORG`: Organization name
-- `GITHUB_APP_ID`: GitHub App ID (for authentication)
-- `GITHUB_AUTH_CLIENT_ID`: OAuth App client ID (for authentication)
-- `GITHUB_AUTH_CLIENT_SECRET`: OAuth App client secret (for authentication)
+- `GITHUB_ORG`: GitHub organization name
+- `GITHUB_AUTH_CLIENT_ID`: OAuth App client ID (for sign-in)
+- `GITHUB_AUTH_CLIENT_SECRET`: OAuth App client secret (for sign-in)
+- `GITHUB_APP_ID`: GitHub App ID (for integrations)
 - `GITHUB_CLIENT_ID`: GitHub App client ID (for integrations)
 - `GITHUB_CLIENT_SECRET`: GitHub App client secret (for integrations)
-- `GITHUB_PRIVATE_KEY`: GitHub App private key (for integrations)
-- `GITHUB_TOKEN`: Personal access token or GitHub App token
+- `GITHUB_PRIVATE_KEY`: GitHub App RSA private key (for integrations) — must preserve newlines (use a YAML block scalar `|` if embedding in config)
 
 **Optional environment variables:**
 
-- `GITHUB_ORG`: Organization name (defaults to all accessible orgs)
-- `GITHUB_HOST`: GitHub Enterprise hostname (defaults to `github.com`)
-- `GITHUB_AUTH_CLIENT_*`: If absent, will use `GITHUB_CLIENT_*` instead
+- `GITHUB_PRIVATE_KEY_BASE64`: Base64-encoded alternative to `GITHUB_PRIVATE_KEY`. When set, the entrypoint decodes it automatically. Use this when newlines in the raw key cause shell/environment issues.
+- `GITHUB_TOKEN`: Personal access token (fallback for non-App integrations)
 
-Check a complete configuration on our [GitHub Profile example](https://github.com/veecode-platform/devportal-samples/tree/main/github).
+:::note
+If `GITHUB_AUTH_CLIENT_ID` is not set, the entrypoint automatically copies the value of `GITHUB_CLIENT_ID` to it. Both variables must ultimately resolve to the same OAuth App credentials for sign-in to work.
+:::
 
-Also please check our [GitHub](/devportal/integrations/github) guide for more information on how to obtain the required credentials to populate the environment variables.
+For details on creating a GitHub OAuth App and GitHub App, see the [GitHub integration guide](/devportal/integrations/GitHub/github-auth).
+
+---
 
 ### GitLab Profile
 
@@ -134,10 +142,12 @@ services:
       - "7007:7007"
     environment:
       - VEECODE_PROFILE=gitlab
-      - GITLAB_TOKEN=${GITLAB_TOKEN}
-      - GITLAB_CLIENT_ID=${GITLAB_CLIENT_ID}
-      - GITLAB_CLIENT_SECRET=${GITLAB_CLIENT_SECRET}
-      - GITLAB_GROUP=my-group  # optional
+      - GITLAB_HOST
+      - GITLAB_AUTH_CLIENT_ID
+      - GITLAB_AUTH_CLIENT_SECRET
+      - GITLAB_TOKEN
+      - GITLAB_GROUP
+      - GITLAB_GROUP_PATTERN
 ```
 
 Then run:
@@ -149,19 +159,75 @@ docker compose up --no-log-prefix
 **What it configures:**
 
 - GitLab OAuth authentication
-- GitLab catalog provider
+- GitLab catalog provider for group/repo discovery
 - GitLab integration
 
 **Required environment variables:**
 
-- `GITLAB_TOKEN`: Personal access token
-- `GITLAB_CLIENT_ID`: OAuth App client ID
-- `GITLAB_CLIENT_SECRET`: OAuth App client secret
+- `GITLAB_HOST`: GitLab hostname — e.g., `gitlab.com` or `gitlab.example.com`. There is no default; the container will fail to connect if this is unset.
+- `GITLAB_AUTH_CLIENT_ID`: OAuth Application ID (for sign-in)
+- `GITLAB_AUTH_CLIENT_SECRET`: OAuth Application Secret (for sign-in)
+- `GITLAB_TOKEN`: Personal or Group Access Token with `read_api` scope (for catalog integration)
+- `GITLAB_GROUP`: Root group for org sync and repository discovery (e.g., `my-org`)
 
 **Optional environment variables:**
 
-- `GITLAB_HOST`: GitLab instance hostname (defaults to `gitlab.com`)
-- `GITLAB_GROUP`: Group name for catalog discovery
+- `GITLAB_GROUP_PATTERN`: Pattern to match groups during catalog sync (defaults to `[\s\S]*` — all groups)
+
+For details on creating a GitLab OAuth Application, see the [GitLab integration guide](/devportal/integrations/GitLab/gitlab-auth).
+
+:::caution
+The correct variable names are `GITLAB_AUTH_CLIENT_ID` and `GITLAB_AUTH_CLIENT_SECRET`. Do not use `GITLAB_CLIENT_ID` or `GITLAB_CLIENT_SECRET` — these are not read by the profile config and GitLab OAuth will silently fail.
+:::
+
+---
+
+### Keycloak Profile
+
+Create a `docker-compose.yml`:
+
+```yaml
+services:
+  devportal:
+    image: veecode/devportal:latest
+    ports:
+      - "7007:7007"
+    environment:
+      - VEECODE_PROFILE=keycloak
+      - KEYCLOAK_BASE_URL
+      - KEYCLOAK_REALM
+      - KEYCLOAK_CLIENT_ID
+      - KEYCLOAK_CLIENT_SECRET
+      - AUTH_SESSION_SECRET
+```
+
+Then run:
+
+```bash
+docker compose up --no-log-prefix
+```
+
+**What it configures:**
+
+- Keycloak OIDC authentication (sign-in via Keycloak)
+- Keycloak organization sync (users and groups from the realm)
+- Session cookie management
+
+**Required environment variables:**
+
+- `KEYCLOAK_BASE_URL`: Full URL to your Keycloak server — e.g., `https://auth.example.com`
+- `KEYCLOAK_REALM`: Keycloak realm name — e.g., `my-realm`
+- `KEYCLOAK_CLIENT_ID`: Client ID configured in Keycloak
+- `KEYCLOAK_CLIENT_SECRET`: Client secret from Keycloak
+- `AUTH_SESSION_SECRET`: Random string used to sign session cookies (any long random string)
+
+**Optional environment variables:**
+
+- `KEYCLOAK_METADATA_URL`: Full OIDC discovery URL. If not set, the entrypoint derives it as `$KEYCLOAK_BASE_URL/realms/$KEYCLOAK_REALM`.
+
+For setup instructions, see the [Keycloak integration guide](/devportal/integrations/Keycloak/keycloak-auth).
+
+---
 
 ### Azure DevOps Profile
 
@@ -179,8 +245,9 @@ services:
       - AZURE_CLIENT_ID
       - AZURE_CLIENT_SECRET
       - AZURE_ORGANIZATION
-      - AZURE_PROJECT
       - AZURE_TOKEN
+      - AUTH_SESSION_SECRET
+      - AZURE_PROJECT
 ```
 
 Then run:
@@ -191,27 +258,35 @@ docker compose up --no-log-prefix
 
 **What it configures:**
 
-- Azure DevOps authentication
-- Azure Repos catalog provider
+- Microsoft (Azure Entra ID) authentication
+- Azure DevOps catalog provider for repo discovery
+- Microsoft Graph org sync (users and groups)
 - Azure DevOps integration
 
 **Required environment variables:**
 
-- `AZURE_TENANT_ID`: Azure tenant ID for authentication
-- `AZURE_CLIENT_ID`: Azure application client ID
+- `AZURE_TENANT_ID`: Azure Active Directory tenant ID (used for both auth and org sync)
+- `AZURE_CLIENT_ID`: Azure application (client) ID
 - `AZURE_CLIENT_SECRET`: Azure application client secret
 - `AZURE_ORGANIZATION`: Azure DevOps organization name
-- `AZURE_TOKEN`: Personal access token
+- `AZURE_TOKEN`: Personal access token with `Code (Read)`, `Graph (Read)`, `Project and Team (Read)` scopes
+- `AUTH_SESSION_SECRET`: Random string used to sign session cookies
 
 **Optional environment variables:**
 
-- `AZURE_PROJECT`: Specific project name (defaults to all projects)
+- `AZURE_PROJECT`: Specific Azure DevOps project to limit repo discovery. If unset, all projects in the organization are scanned.
+
+:::note
+`AZURE_CLIENT_ID` and `AZURE_TENANT_ID` are used for both Microsoft Entra ID sign-in and Microsoft Graph org sync. Ensure the app registration has the necessary Microsoft Graph API permissions (`User.Read.All`, `Group.Read.All`).
+:::
+
+For setup instructions, see the [Azure integration guide](/devportal/integrations/Azure).
+
+---
 
 ### LDAP Profile
 
-For organizations still stuck with LDAP authentication (such as classic Active Directory), you can use the `ldap` profile.
-
-Use the following sample docker-compose.yml:
+For organizations using standard LDAP directories (OpenLDAP, FreeIPA, etc.).
 
 ```yaml
 services:
@@ -221,38 +296,113 @@ services:
       - "7007:7007"
     environment:
       - VEECODE_PROFILE=ldap
+      - LDAP_URL
       - LDAP_DN
       - LDAP_SECRET
-      - LDAP_URL
       - LDAP_USERS_BASE_DN
-      - LDAP_USERS_FILTER
       - LDAP_GROUPS_BASE_DN
-      - LDAP_GROUPS_FILTER
 ```
 
 **What it configures:**
 
 - LDAP authentication
-- LDAP integration for organization catalog sync
+- LDAP org sync (users and groups)
 
 **Required environment variables:**
 
-- `LDAP_DN`: login DN (distinguished name), such as "cn=admin,dc=vee,dc=codes"
-- `LDAP_SECRET`: connection password
-- `LDAP_URL`: LDAP server URL, such as "ldap://ldap.vee.codes"
-- `LDAP_USERS_BASE_DN`: users base DN, such as "ou=People,dc=vee,dc=codes"
-- `LDAP_GROUPS_BASE_DN`: groups base DN, such as "ou=Groups,dc=vee,dc=codes"
-- `LDAP_USERS_FILTER`: users filter
-- `LDAP_GROUPS_FILTER`: groups filter
+- `LDAP_URL`: LDAP server URL — e.g., `ldap://ldap.example.com`
+- `LDAP_DN`: Bind DN for service account — e.g., `cn=admin,dc=example,dc=com`
+- `LDAP_SECRET`: Bind password for the service account
+- `LDAP_USERS_BASE_DN`: Base DN for user search — e.g., `ou=People,dc=example,dc=com`
+- `LDAP_GROUPS_BASE_DN`: Base DN for group search — e.g., `ou=Groups,dc=example,dc=com`
 
 **Optional environment variables:**
 
-- `LDAP_USERS_FILTER`: defaults to "(uid=*)"
-- `LDAP_GROUPS_FILTER`: defaults to "(objectClass=groupOfNames)"
+- `LDAP_USERS_FILTER`: LDAP filter for users (defaults to `(uid=*)`)
+- `LDAP_GROUPS_FILTER`: LDAP filter for groups (defaults to `(objectClass=groupOfNames)`)
 
-## Combining Profiles with Custom Config
+For setup instructions, see the [LDAP integration guide](/devportal/integrations/LDAP).
 
-You can use a profile as a base and override specific settings with a custom config file:
+---
+
+### LDAP Active Directory Profile (`ldap-ad`)
+
+A variant of the LDAP profile tuned for Microsoft Active Directory (and Samba AD). Uses `sAMAccountName` as the username attribute and AD-style object class filters by default.
+
+```yaml
+services:
+  devportal:
+    image: veecode/devportal:latest
+    ports:
+      - "7007:7007"
+    environment:
+      - VEECODE_PROFILE=ldap-ad
+      - LDAP_URL
+      - LDAP_DN
+      - LDAP_SECRET
+      - LDAP_USERS_BASE_DN
+      - LDAP_GROUPS_BASE_DN
+      - LDAP_USERS_FILTER
+      - LDAP_GROUPS_FILTER
+```
+
+**What it configures:**
+
+- LDAP authentication using `sAMAccountName` as the login attribute
+- AD-tuned LDAP org sync with `cn`/`memberOf`/`member` attribute mapping
+
+**Required environment variables:**
+
+- `LDAP_URL`: LDAP/LDAPS server URL — e.g., `ldaps://dc.example.com`
+- `LDAP_DN`: Bind DN for service account — e.g., `CN=svc-devportal,OU=ServiceAccounts,DC=example,DC=com`
+- `LDAP_SECRET`: Bind password for the service account
+- `LDAP_USERS_BASE_DN`: Base DN for user search — e.g., `OU=Users,DC=example,DC=com`
+- `LDAP_GROUPS_BASE_DN`: Base DN for group search — e.g., `OU=Groups,DC=example,DC=com`
+- `LDAP_USERS_FILTER`: LDAP filter for users — e.g., `(&(objectClass=user)(objectCategory=person))`
+- `LDAP_GROUPS_FILTER`: LDAP filter for groups — e.g., `(objectClass=group)`
+
+**Optional / auto-defaulted environment variables:**
+
+- `LDAP_TLS_REJECT_UNAUTHORIZED`: Whether to reject untrusted TLS certificates. Defaults to `true`. Set to `false` when using self-signed certs (not recommended for production).
+- `LDAP_SYNC_FREQUENCY`: ISO 8601 duration for org sync interval. Defaults to `PT1H` (every hour).
+
+:::note
+Unlike the `ldap` profile, `LDAP_USERS_FILTER` and `LDAP_GROUPS_FILTER` have no built-in defaults in `ldap-ad` and must be provided to match your AD schema.
+:::
+
+For setup instructions, see the [LDAP integration guide](/devportal/integrations/LDAP).
+
+---
+
+## Operational Environment Variables
+
+The following variables apply to any profile and control runtime behavior:
+
+| Variable | Description | Default |
+|---|---|---|
+| `DEVELOPMENT` | Set to `true` to enable nodemon hot-reload and watch config files for changes. Useful during local setup. | `false` |
+| `DEBUG_PORT` | When set, starts the Node.js process with `--inspect=0.0.0.0:<port>` for remote debugging. | unset |
+| `CATALOG_INDEX_REFRESH` | Set to `true` to force re-download of the marketplace plugin catalog index from OCI on startup. Use when the marketplace is empty. | `false` |
+| `CATALOG_INDEX_IMAGE` | OCI image containing marketplace catalog entities. | `quay.io/veecode/plugin-catalog-index:latest` |
+| `VEECODE_APP_CONFIG` | Base64-encoded full `app-config` blob. Decoded into `app-config.saas.yaml` and loaded last (SaaS mode). Not needed for self-hosted. | unset |
+
+---
+
+## Config Merge Order
+
+When a profile and a custom config file are both used, all config files are merged in this order (later entries override earlier ones):
+
+1. `app-config.yaml` — base image defaults
+2. `app-config.production.yaml` — production overrides baked into image
+3. `app-config.{profile}.yaml` — profile-specific config (if `VEECODE_PROFILE` is set)
+4. `app-config.distro.yaml` — distro-level overrides (baked in)
+5. `app-config.local.yaml` — your custom file, mounted at `/app/app-config.local.yaml`
+6. `dynamic-plugins-root/app-config.dynamic-plugins.yaml` — generated by the plugin install script at startup
+7. `app-config.saas.yaml` — decoded from `VEECODE_APP_CONFIG` (SaaS mode only)
+
+Your `app-config.local.yaml` (layer 5) takes precedence over the base image and profile defaults, but is itself superseded by plugin-injected config (layer 6). If a key you set in `local.yaml` seems to be ignored, check whether a plugin's `pluginConfig` block is overriding it in layer 6.
+
+Example:
 
 ```yaml
 services:
@@ -262,47 +412,58 @@ services:
       - "7007:7007"
     environment:
       - VEECODE_PROFILE=github
-      - GITHUB_TOKEN
+      - GITHUB_ORG
+      - GITHUB_AUTH_CLIENT_ID
+      - GITHUB_AUTH_CLIENT_SECRET
+      - GITHUB_APP_ID
+      - GITHUB_CLIENT_ID
+      - GITHUB_CLIENT_SECRET
+      - GITHUB_PRIVATE_KEY
     volumes:
       - ./app-config.local.yaml:/app/app-config.local.yaml:ro
 ```
 
-The configuration is merged in this order:
-
-1. Default configuration (built into image)
-2. Profile configuration (from `VEECODE_PROFILE`)
-3. Custom configuration (from `/app/app-config.local.yaml`)
+---
 
 ## Getting OAuth Credentials
 
 ### GitHub App / OAuth App / PAT
 
-Please check our [GitHub](/devportal/integrations/github) guide for more information.
+See the [GitHub integration guide](/devportal/integrations/GitHub/github-auth).
 
 ### GitLab OAuth App
 
-1. Go to **User Settings** → **Applications**
+1. Go to **User Settings** → **Applications** (or **Admin Area** → **Applications** for instance-wide)
 2. Set **Redirect URI**: `http://localhost:7007/api/auth/gitlab/handler/frame`
 3. Select scopes: `read_user`, `read_repository`, `write_repository`, `openid`, `profile`, `email`
-4. Copy the **Application ID** and **Secret**
+4. Copy the **Application ID** (→ `GITLAB_AUTH_CLIENT_ID`) and **Secret** (→ `GITLAB_AUTH_CLIENT_SECRET`)
 
 ### Azure DevOps Token
 
 1. Go to **User settings** → **Personal access tokens**
 2. Create a new token with scopes: `Code (Read)`, `Graph (Read)`, `Project and Team (Read)`
-3. Copy the token value
+3. Copy the token value (→ `AZURE_TOKEN`)
+
+### Keycloak Client
+
+1. In your Keycloak Admin Console, open your realm and go to **Clients** → **Create**
+2. Set **Client ID** and enable **Client authentication**
+3. Set **Valid redirect URIs**: `http://localhost:7007/api/auth/oidc/handler/frame`
+4. Copy the client secret from the **Credentials** tab
+
+---
 
 ## Troubleshooting
 
-### Profile not working
+### Profile not loading
 
-Check the container logs:
+Check the container logs for a line like `VEECODE: Loading GitHub configuration...` during startup:
 
 ```bash
 docker logs devportal
 ```
 
-Look for profile-related messages during startup.
+If no profile message appears, ensure `VEECODE_PROFILE` is set to an exact profile name (lowercase).
 
 ### Authentication fails
 
@@ -310,14 +471,26 @@ Verify your OAuth callback URLs match exactly:
 
 - GitHub: `http://localhost:7007/api/auth/github/handler/frame`
 - GitLab: `http://localhost:7007/api/auth/gitlab/handler/frame`
+- Keycloak (OIDC): `http://localhost:7007/api/auth/oidc/handler/frame`
+- Azure: `http://localhost:7007/api/auth/microsoft/handler/frame`
 
 ### Catalog not populating
 
 Ensure your token has the correct permissions:
 
 - GitHub: `repo` scope for private repos, `public_repo` for public
-- GitLab: `read_repository` scope
+- GitLab: `read_api` scope
 - Azure: `Code (Read)` scope
+
+### Marketplace is empty
+
+Force a fresh catalog index download on next startup:
+
+```bash
+docker run ... -e CATALOG_INDEX_REFRESH=true veecode/devportal:latest
+```
+
+---
 
 ## Next Steps
 

--- a/devportal/installation-guide/docker-local/profiles.md
+++ b/devportal/installation-guide/docker-local/profiles.md
@@ -223,7 +223,7 @@ docker compose up --no-log-prefix
 
 **Optional environment variables:**
 
-- `KEYCLOAK_METADATA_URL`: Full OIDC discovery URL. If not set, the entrypoint derives it as `$KEYCLOAK_BASE_URL/realms/$KEYCLOAK_REALM`.
+- `KEYCLOAK_METADATA_URL`: Computed and logged by the entrypoint as `$KEYCLOAK_BASE_URL/realms/$KEYCLOAK_REALM`. The bundled config builds the discovery URL from `KEYCLOAK_BASE_URL` + `KEYCLOAK_REALM` directly, so setting this variable alone does not change it — override `auth.providers` in `app-config.local.yaml` for a non-standard endpoint.
 
 For setup instructions, see the [Keycloak integration guide](/devportal/integrations/Keycloak/keycloak-auth).
 
@@ -271,10 +271,7 @@ docker compose up --no-log-prefix
 - `AZURE_ORGANIZATION`: Azure DevOps organization name
 - `AZURE_TOKEN`: Personal access token with `Code (Read)`, `Graph (Read)`, `Project and Team (Read)` scopes
 - `AUTH_SESSION_SECRET`: Random string used to sign session cookies
-
-**Optional environment variables:**
-
-- `AZURE_PROJECT`: Specific Azure DevOps project to limit repo discovery. If unset, all projects in the organization are scanned.
+- `AZURE_PROJECT`: Azure DevOps project to scan for repos. Set to `*` to discover across all projects in the organization. There is no default, so set it explicitly.
 
 :::note
 `AZURE_CLIENT_ID` and `AZURE_TENANT_ID` are used for both Microsoft Entra ID sign-in and Microsoft Graph org sync. Ensure the app registration has the necessary Microsoft Graph API permissions (`User.Read.All`, `Group.Read.All`).

--- a/devportal/installation-guide/installation-guide.md
+++ b/devportal/installation-guide/installation-guide.md
@@ -38,7 +38,7 @@ export const Card = ({children, title, link}) => (
 
 <Card title="Production Setup" link="./production-setup">Learn how to install a self-hosted and production-ready Developer Portal on your own infrastructure.</Card>
 
-<Card title="Customization" link="/devportal/customization/customization">Learn how to customize your Developer Portal.</Card>
+<Card title="Customization" link="/devportal/customization">Learn how to customize your Developer Portal.</Card>
 
 <Card title="FAQs" link="./FAQs">Frequently Asked Questions.</Card>
 

--- a/devportal/installation-guide/installation-guide.md
+++ b/devportal/installation-guide/installation-guide.md
@@ -38,8 +38,8 @@ export const Card = ({children, title, link}) => (
 
 <Card title="Production Setup" link="./production-setup">Learn how to install a self-hosted and production-ready Developer Portal on your own infrastructure.</Card>
 
-<Card title="Customization" link="./Customization">Learn how to customize your Developer Portal.</Card>
+<Card title="Customization" link="/devportal/customization/customization">Learn how to customize your Developer Portal.</Card>
 
-<Card title="FAQs" link="./FAQs">Frequently Asked Question.</Card>
+<Card title="FAQs" link="./FAQs">Frequently Asked Questions.</Card>
 
 </div>

--- a/devportal/installation-guide/production-setup/plan.md
+++ b/devportal/installation-guide/production-setup/plan.md
@@ -4,4 +4,126 @@ sidebar_label: Plan your setup
 title: Plan your setup
 ---
 
-TODO
+Before running `helm upgrade --install`, take a few minutes to answer these questions. The decisions here map directly to values in your `values.yaml`.
+
+## Hostname and TLS
+
+DevPortal needs a stable, publicly resolvable DNS hostname.
+
+- Set `global.host` to the hostname (e.g., `devportal.example.com`).
+- Set `global.protocol: https` for production.
+- Configure `upstream.ingress.tls` with a TLS secret (cert-manager with Let's Encrypt is the recommended approach).
+
+```yaml
+global:
+  host: devportal.example.com
+  protocol: https
+  port: ''
+upstream:
+  ingress:
+    enabled: true
+    className: nginx   # or 'kong' — must match your installed ingress controller
+    tls:
+      - secretName: devportal-tls
+        hosts:
+          - devportal.example.com
+```
+
+## Database
+
+DevPortal requires a PostgreSQL database. SQLite is not supported in production.
+
+- Provision a PostgreSQL instance (RDS, Cloud SQL, Azure Database, or self-hosted).
+- Create a database named `platform_devportal` and a dedicated user.
+- Ensure the Kubernetes cluster can reach the database (network policy / VPC peering / security groups).
+- Supply the connection details under `upstream.backstage.appConfig.backend.database`.
+
+Do not commit database passwords in `values.yaml`. Use `upstream.backstage.extraEnvVarsSecret` and reference them as `${DB_PASSWORD}` in the config.
+
+## Secrets strategy
+
+All tokens, client secrets, and passwords should be stored in a Kubernetes Secret:
+
+```bash
+kubectl create secret generic devportal-secrets \
+  --namespace platform \
+  --from-literal=GITHUB_TOKEN=... \
+  --from-literal=GITHUB_AUTH_CLIENT_ID=... \
+  --from-literal=GITHUB_AUTH_CLIENT_SECRET=...
+```
+
+Reference it in `values.yaml`:
+
+```yaml
+upstream:
+  backstage:
+    extraEnvVarsSecret: devportal-secrets
+```
+
+For GitOps workflows, use an external secrets operator (e.g., External Secrets Operator, Vault Agent) to populate the Kubernetes Secret from your secrets store.
+
+## Git provider
+
+Decide which Git provider(s) you need before writing `values.yaml`. The required credentials differ:
+
+| Provider | Sign-in | Backend catalog access |
+|---|---|---|
+| GitHub | OAuth App (Client ID + Secret) | Personal Access Token or GitHub App |
+| GitLab | OAuth Application (Client ID + Secret) | Personal Access Token |
+
+See [Configure Git integrations](../simple-setup/configure-git-integrations.md) for the exact `appConfig` keys.
+
+## Resource sizing
+
+The chart does not enforce resource limits by default. For a production deployment, set them under `upstream.backstage.resources`:
+
+```yaml
+upstream:
+  backstage:
+    resources:
+      requests:
+        cpu: 500m
+        memory: 512Mi
+      limits:
+        cpu: 1000m
+        memory: 1Gi
+```
+
+Scale horizontally with care: DevPortal's backend uses in-memory caching, so multiple replicas require session affinity on the ingress. A single replica with appropriate CPU/memory is typically sufficient for small to medium teams.
+
+## Namespace
+
+The convention in this documentation is to deploy DevPortal into the `platform` namespace:
+
+```bash
+kubectl create namespace platform
+```
+
+If you use a different namespace, update `--namespace` in all `kubectl` and `helm` commands.
+
+## RBAC
+
+DevPortal ships with three built-in roles:
+
+| Role | Intended audience |
+|---|---|
+| `role:default/admin` | Platform administrators |
+| `role:default/developer` | Development team members |
+| `role:default/viewer` | Read-only observers |
+
+To create the necessary cluster roles automatically, set:
+
+```yaml
+createClusterRoles: true
+```
+
+Assign users to roles using the Backstage RBAC policy. See the [integrations documentation](/devportal/integrations) for details.
+
+## Checklist before deploying
+
+- [ ] DNS record created and resolving to the cluster load balancer
+- [ ] TLS certificate provisioned (or cert-manager configured to issue one)
+- [ ] PostgreSQL database and user created, network access confirmed
+- [ ] Git provider OAuth App created with correct callback URL
+- [ ] Kubernetes Secret created with all required tokens and secrets
+- [ ] `values.yaml` reviewed — no plaintext secrets, correct hostname, correct ingress class

--- a/devportal/installation-guide/production-setup/plan.md
+++ b/devportal/installation-guide/production-setup/plan.md
@@ -117,7 +117,7 @@ To create the necessary cluster roles automatically, set:
 createClusterRoles: true
 ```
 
-Assign users to roles using the Backstage RBAC policy. See the [integrations documentation](/devportal/integrations) for details.
+Assign users to roles using the Backstage RBAC policy. See the [RBAC documentation](/devportal/rbac/permissions) for details.
 
 ## Checklist before deploying
 

--- a/devportal/installation-guide/production-setup/production-setup.md
+++ b/devportal/installation-guide/production-setup/production-setup.md
@@ -4,8 +4,31 @@ sidebar_label: Production Setup
 title: Production Setup
 ---
 
-:::tip
-We are working furiously to update this section. Please have patience while we take care of it.
-:::
+This section covers deploying VeeCode DevPortal on a production Kubernetes cluster using the official `veecode-devportal` Helm chart.
 
-TODO
+## What is covered
+
+- [Plan your setup](plan.md) — sizing, database, ingress, and secrets strategy before you deploy
+- [Setup guide](setup.md) — step-by-step Helm deployment with GitHub or GitLab
+
+## When to use this guide
+
+Use this guide when you need a persistent, team-accessible DevPortal instance — for example, a staging or production environment. If you are experimenting locally, see the [Simple Setup](../simple-setup/simple-setup.md) or [VKDR Local](../vkdr-local/vkdr-setup.md) guides instead.
+
+## Key requirements
+
+- Kubernetes cluster with an ingress controller (nginx or Kong)
+- PostgreSQL database accessible from the cluster
+- DNS hostname with a valid TLS certificate (recommended: cert-manager + Let's Encrypt)
+- Git provider credentials (GitHub OAuth App + PAT, or GitLab OAuth App + PAT)
+
+## Helm chart
+
+| | |
+|---|---|
+| **Repo** | `https://veecode-platform.github.io/next-charts` |
+| **Chart** | `veecode-devportal/veecode-devportal` |
+| **Image** | `veecode/devportal:1.4.5` |
+| **ArtifactHub** | [veecode-platform-next/veecode-devportal](https://artifacthub.io/packages/helm/veecode-platform-next/veecode-devportal) |
+
+See [Understand the Helm Chart](../understand-chart) for a detailed breakdown of chart values.

--- a/devportal/installation-guide/production-setup/setup.md
+++ b/devportal/installation-guide/production-setup/setup.md
@@ -146,7 +146,7 @@ upstream:
             port: 5432
             database: platform_devportal
             user: <db-user>
-            password: <db-password>
+            password: ${POSTGRES_PASSWORD} # injected from the devportal-secrets Secret — do not inline a real password in values.yaml
       integrations:
         github:
           - host: github.com
@@ -202,7 +202,7 @@ upstream:
             port: 5432
             database: platform_devportal
             user: <db-user>
-            password: <db-password>
+            password: ${POSTGRES_PASSWORD} # injected from the devportal-secrets Secret — do not inline a real password in values.yaml
       integrations:
         gitlab:
           - host: gitlab.com    # or your self-hosted hostname
@@ -249,7 +249,7 @@ helm upgrade --install veecode-devportal \
 Once the rollout completes, open `https://devportal.example.com` in your browser. You should reach the DevPortal login screen.
 
 ```bash
-kubectl rollout status deployment/veecode-devportal -n platform
+kubectl rollout status deployment/veecode-devportal-backstage -n platform
 ```
 
 ---

--- a/devportal/installation-guide/production-setup/setup.md
+++ b/devportal/installation-guide/production-setup/setup.md
@@ -4,405 +4,260 @@ sidebar_label: Production Setup
 title: Production Setup
 ---
 
-:::warning
-The information in this section needs updating and should be ignored. Please have patience while we take care of it.
-:::
-
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-export const your_domain = "devportal.yourdomain.com";
+Welcome to the VeeCode Platform DevPortal production installation guide. This guide walks through installing DevPortal on a production-grade Kubernetes cluster using the official Helm chart.
 
-Welcome to the VeeCode Platform DevPortal complete product installation guide. This guide will help you install the product. You will need an Kubernetes cluster for this installation.
+## Overview
 
-## **Overview**
+This guide covers:
 
-This guide will cover the following steps:
+1. **Prerequisites** — cluster, database, DNS, and credentials
+2. **Creating a catalog repository** in your Git provider
+3. **Configuring and deploying** DevPortal via Helm
+4. **Accessing the portal**
 
-1. **Creating a Repository for Hosting Your Catalog in the DevPortal**
-2. **Configuring the DevPortal with your credentials and deploying it to your cluster**
-3. **Accessing the DevPortal**
+## Prerequisites
 
-By following these steps, you'll be able to install the DevPortal product on your cluster and explore its features.
+- A Kubernetes cluster (cloud-managed or self-managed)
+- `kubectl` and `helm` (v3) installed and configured
+- A PostgreSQL database accessible from the cluster
+- A DNS hostname pointing to your cluster's ingress load balancer (e.g., `devportal.example.com`)
+- An ingress controller deployed in the cluster (nginx or Kong)
+- A Git provider account (GitHub or GitLab) with credentials
 
-To continue, select your preferred provider:
+<Tabs groupId="providers">
+<TabItem value="github" label="GitHub">
 
-<Tabs groupId="providers1">
-<TabItem value="Github" label="Github">
+**Required GitHub credentials:**
 
-## **Prerequisites (GitHub)**
+- **GitHub OAuth App** — Client ID and Client Secret for user sign-in.
+  1. Go to [GitHub Developer Settings](https://github.com/settings/developers) → **New OAuth App**.
+  2. Set **Homepage URL** to `https://devportal.example.com`.
+  3. Set **Authorization callback URL** to `https://devportal.example.com/api/auth/github/handler/frame`.
+  4. Note the **Client ID** and generate a **Client Secret**.
 
-Before you start, you'll need to have the following:
+- **GitHub Personal Access Token (PAT)** — for backend catalog and API access.
+  1. Go to [GitHub Tokens](https://github.com/settings/tokens) → **Generate new token (classic)**.
+  2. Select scopes: `repo` (all), `workflow`.
+  3. Note the token; it will not be shown again.
 
-- An existing Kubernetes cluster for the installation.
-- A GitHub account.
-- A GitHub OAuth App Client ID and Client Secret
-- A GitHub personal access token
-- A PostgreSQL database.
-
-In the next sections, we will provide a brief tutorial on **how to generate the GitHub OAuth App Client ID, Client Secret, and a personal access token**. If you already know how to generate these or have them readily available, feel free to skip the upcoming tutorial and proceed directly to Step 1 of the installation guide.
-
-### Create a new GitHub OAuth App
-
-1. **Create a New OAuth App**
-
- First, **[click here](https://github.com/settings/developers)** and then click on "New OAuth App". Fill in the required information, including:
-
-- **Application name:** Choose a name that's easily identifiable, such as "devportal".
-- **Homepage URL:** https://{your_domain}
-- **Description:** (Optional) Add a brief description of the application, such as "VeeCode DevPortal".
-- **Authorization callback URL:** https://{your_domain}/api/auth/github/handler/frame
-
-Make sure to replace "**{your_domain}**" with the actual domain used in your kubernetes applications.
-
-Leave the "Enable device flow" checkbox unselected and click on "Register application".
-
-2. Write down the **Client ID** and click on "**Generate a New Client Secret**"
-
-After registering the OAuth App, save the Client ID displayed on the screen. Then, click on "**Generate a new client secret**" and save the generated Client Secret.
-
-Finally, click on "Update application" at the bottom of the page to save your changes.
-
-By completing these steps, you have successfully generated a GitHub OAuth App and collected the Client ID and Client Secret to use in your application.
-
-The reason for generating these credentials is to enable the Devportal to authenticate users via GitHub. The Client ID uniquely identifies your application, while the Client Secret serves as a secret key for authentication. This OAuth App allows the Devportal to securely connect to GitHub's API and access user information, ensuring a seamless integration between the Devportal and users' GitHub accounts.
-
-### Create an Access Token on GitHub
-1. **Create a new Access Token**
-
-To generate an access token, **[click here](https://github.com/settings/tokens)** and then click "Generate new token". Choose the **classic mode** option and fill in the requested information.
-
-- Name: any proper label, such as "devportal-token"
-- Expiration date: we recommend setting it to 90 days
-
-2. **Select the Correct Scopes** for the Token In the "Select scopes" section, select the "repo" scopes (select all) and "workflow" scopes. Make sure no other option is selected.
-
-3. **Create the Token**
-
-Click "Generate token" to create the access token. Copy the token and store it in a secure location, as it will only be displayed once.
-
-With these three steps, you have successfully generated an access token on GitHub. Make sure to use to keep those safe.
-
-The reason for the generation of these credentials is so that you can have access to the Devportal plugins.
+Store these as a Kubernetes Secret before deploying (see [Step 2](#step-2-create-a-kubernetes-secret-for-credentials)).
 
 </TabItem>
+<TabItem value="gitlab" label="GitLab">
 
-<TabItem value="Gitlab" label="Gitlab">
+**Required GitLab credentials:**
 
-## **Prerequisites (GitLab)**
+- **GitLab Personal Access Token** — for backend catalog and API access. Create one at **GitLab → User Settings → Access Tokens** with scopes `read_api`, `read_repository`.
 
-Before you start, you'll need to have the following:
+- **GitLab OAuth Application** (optional, for user sign-in):
+  1. Go to **GitLab → User Settings → Applications**.
+  2. Set **Redirect URI** to `https://devportal.example.com/api/auth/gitlab/handler/frame`.
+  3. Enable scopes: `read_user`, `openid`, `email`, `profile`.
+  4. Note the **Application ID** and **Secret**.
 
-- An existing Kubernetes cluster for the installation.
-- A GitLab account.
-- A GitLab personal access token.
-- A PostgreSQL database.
-
-In the next sections, we'll provide a brief tutorial on **how to generate a GitLab personal access token**. If you already know how to generate this token or if you have it readily available, feel free to skip the upcoming section and proceed directly to Step 1 of the installation guide.
-
-### Create an Access Token on GitLab
-
-1. **Log in to your GitLab account**: Visit **`https://gitlab.com/users/sign_in`** and enter your credentials to log in.
-2. **Navigate to your profile settings**: Click on your account icon in the upper right corner of the GitLab interface and select "Settings" from the dropdown menu.
-3. **Go to the Personal Access Tokens section**: On the left side menu, click on "Access Tokens".
-4. **Create a new token**:
-    - **Name**: Enter a name for the token that describes its purpose, such as "Personal Access Token".
-    - **Expires at**: Optionally, you can set an expiration date for the token.
-    - **Scopes**: Choose the appropriate scopes for this token. For instance, if you want the token to be able to read and write to repositories, you should select the "read_repository" and "write_repository" scopes.
-5. **Create the token**: Click the "Create personal access token" button at the bottom of the page.
-6. **Copy your token**: After creating the token, you will see a token value on the page. This is your personal access token and it will be shown only once, so copy it and keep it in a safe place.
-The reason for the generation of these credentials is so that you can have access to the Devportal plugins.
-
-
-**Important:** Keep your Personal Access Token saved, as you will need it in subsequent steps of the installation process.
+Store these as a Kubernetes Secret before deploying (see [Step 2](#step-2-create-a-kubernetes-secret-for-credentials)).
 
 </TabItem>
 </Tabs>
 
-## **Step 1: Creating a Repository for Hosting Your Catalog in the DevPortal**
+---
 
-The initial step to using the DevPortal involves setting up a repository to host your catalog. The catalog maps and exposes specifications, APIs, templates, and other resources. Depending on your preferred provider (GitHub or GitLab), the process may differ slightly.
+## Step 1: Fork the sample catalog
 
-First, select your preferred provider:
+Fork [veecode-platform/public-catalog](https://github.com/veecode-platform/public-catalog) into your Git account or organization. This gives you a starting catalog repository that DevPortal can index.
 
-<Tabs groupId="providers1">
-<TabItem value="Github" label="Github">
+Note the repository name — you'll reference it in your `values.yaml`.
 
-Creating a repository on Github with the files you have, follows this process:
+---
 
-1. **Go to**  [public-catalog](https://github.com/veecode-platform/public-catalog)  on GitHub.
-2. **In the upper right** corner of the page, click the "Fork" button.
-3. **In "Owner"**, select your account or the organization that you want to fork the repository to. Keep the original repository name and then click "Create fork"
-4. **The repository** will be forked to your account.
-5. **You will** be redirected to your forked repository.
+## Step 2: Create a Kubernetes Secret for credentials
 
-Now you can make changes to your forked repository without affecting the original repository.
+Never put secrets directly in `values.yaml`. Create a Kubernetes Secret in the namespace where DevPortal will run (typically `platform`):
 
-**Important**: Please remember to save the name of the repository you created, as you will need it in subsequent steps of the installation process.
+```bash
+kubectl create namespace platform --dry-run=client -o yaml | kubectl apply -f -
+```
 
-And there you have it! Your GitHub repository is now set up correctly for the DevPortal to map and expose your catalog's contents.
+<Tabs groupId="providers">
+<TabItem value="github" label="GitHub">
 
+```bash
+kubectl create secret generic devportal-secrets \
+  --namespace platform \
+  --from-literal=GITHUB_AUTH_CLIENT_ID=<oauth-client-id> \
+  --from-literal=GITHUB_AUTH_CLIENT_SECRET=<oauth-client-secret> \
+  --from-literal=GITHUB_TOKEN=<personal-access-token>
+```
 
 </TabItem>
+<TabItem value="gitlab" label="GitLab">
 
-<TabItem value="Gitlab" label="Gitlab">
-
-Creating a repository on GitLab with the files you have, follows this process:
-
-1. **Access** [public-catalog](https://github.com/veecode-platform/public-catalog)
-2. **Click on the "Clone" button** and select "Clone with HTTPS".
-3. **Copy** the URL of the repository.
-4. **Log into your GitLab** account and navigate to the "New project" page. You can do this by clicking on the "+" icon on the upper left corner and then selecting "New project/repository".
-5. **Choose** "Import project".
-6. **Select** "Repository by URL" as the source repository.
-7. **Paste** the URL of the repository you want to import into the "Git repository URL" field.
-8. **Click** on the "Import" button".
-
-The repository will be imported to your GitLab account.
-
-**Important**: Please remember to save the name of the repository you created, as you will need it in subsequent steps of the installation process.
-
-Your GitLab repository is now correcly setup for the DevPortal to map and expose your catalog's contents.
+```bash
+kubectl create secret generic devportal-secrets \
+  --namespace platform \
+  --from-literal=GITLAB_TOKEN=<personal-access-token> \
+  --from-literal=GITLAB_AUTH_CLIENT_ID=<oauth-app-id> \
+  --from-literal=GITLAB_AUTH_CLIENT_SECRET=<oauth-app-secret>
+```
 
 </TabItem>
 </Tabs>
 
-## **Step 2: Configuring the DevPortal with your credentials and deploying it to your cluster**
+---
 
-To configure DevPortal deployment, edit the YAML file provided below and **replace** the following information with your own:
+## Step 3: Create your `values.yaml`
 
-The file should be created with the name "values" by default.
+The chart name is `veecode-devportal` from the `veecode-devportal` Helm repository. See [Understand the Helm Chart](../understand-chart) for a full reference of available keys.
 
-<Tabs groupId="providers1">
-<TabItem value="Github" label="Github">
+<Tabs groupId="providers">
+<TabItem value="github" label="GitHub">
 
-1. Copy this values.yaml file:
-    
-    ```yaml
-    replicas: 1
+```yaml
+global:
+  host: devportal.example.com   # your DNS hostname
+  protocol: https
+  port: ''
+
+upstream:
+  enabled: true
+  ingress:
+    enabled: true
+    className: nginx             # or 'kong'
+    tls:
+      - secretName: devportal-tls
+        hosts:
+          - devportal.example.com
+  backstage:
     image:
-      repository: veecode/devportal-bundle
-      tag: latest
-      pullPolicy: IfNotPresent
-    
-    environment: development
-    
-    service:
-      enabled: true
-      name: devportal
-      type: ClusterIP
-      containerPort: 7007
-    
-    ingress:
-      enabled: true
-      host: <devportal-host> #devportal.com
-      className: nginx
-      # className: kong
-      # annotations:
-      #   konghq.com/https-redirect-status-code: "308"
-      #   konghq.com/preserve-host: "true"
-      #   konghq.com/protocols: "https"
-      #   konghq.com/strip-path: "false"
-      tls:
-        secretName: devportal-secret
-    
-    resources:
-      requests:
-        cpu: 500m
-        memory: 512Mi
-      limits:
-        cpu: 1000m
-        memory: 1Gi
-    
+      repository: veecode/devportal
+      tag: "1.4.5"
+    extraEnvVarsSecret: devportal-secrets
     appConfig:
-      title: Devportal
       app:
-        baseUrl: <devportal-host>
+        title: "VeeCode DevPortal"
       backend:
-        baseUrl: <devportal-host>
-        secret: 56616a93-ac28-42ab-929d-6ec1fc008c54
-      database:
-        client: pg
-        connection:
-          host: <database-url>
-          port: 5432
-          database: platform_devportal
-          user: <username>
-          password: <password>
-    
-    auth:
-      providers:
+        database:
+          client: pg
+          connection:
+            host: <db-host>
+            port: 5432
+            database: platform_devportal
+            user: <db-user>
+            password: <db-password>
+      integrations:
         github:
-          clientId: <github-client-id>
-          clientSecret: <github-client-secret>
-    
-    integrations:
-      github:
-        token: <github-token>
-    
-    catalog:
-      providers:
-        github:
-          organization: <github-organization> # string
-          catalogPath: /catalog-info.yaml # string
-          filters:
-            branch: main # Optional. Uses `master` as default
-            repository: <repository-name> #suggestion devportal-catalog
-            validateLocationsExist: true
-    
-    platform:
-      guest:
-        enabled: true
-      apiManagement:
-        enabled: false
-        readOnlyMode: false
-    ```
-    
-2. **Replace `<devportal-host>`**: This placeholder appears in two places: under **`ingress.host`**, and in **`appConfig`** under **`app.baseUrl`** and **`backend.baseUrl`**. Replace it with the hostname where your DevPortal will be accessible, such as **`devportal.yourdomain.com`**.
-3. **Update Database Connection**: In the **`appConfig.database.connection`** section, you should replace:
-    - **`<database-url>`**: Replace it with your PostgreSQL database server's hostname.
-    - **`<username>`** and **`<password>`**: Replace these with the appropriate credentials to access your PostgreSQL database.
-4. **Set GitHub OAuth Credentials**: In the **`auth.providers.github`** section, replace:
-    - **`<github-client-id>`** and **`<github-client-secret>`**: Replace these with your GitHub OAuth app's client ID and client secret.
-5. **Set GitHub Token**: In the **`integrations.github`** section, replace **`<github-token>`** with your GitHub personal access token.
-6. **Configure Catalog Repository**: In the **`catalog.providers.github`** section:
-    - Replace **`<github-organization>`**: This should be replaced with your GitHub username or organization name.
-    - Replace **`<repository-name>`**: This should be replaced with the name of your GitHub repository.
+          - host: github.com
+            token: ${GITHUB_TOKEN}
+      auth:
+        providers:
+          github:
+            development:
+              clientId: ${GITHUB_AUTH_CLIENT_ID}
+              clientSecret: ${GITHUB_AUTH_CLIENT_SECRET}
+      catalog:
+        providers:
+          github:
+            myOrg:
+              organization: <your-github-org>
+              catalogPath: /catalog-info.yaml
+              filters:
+                branch: main
+                repository: public-catalog
+```
 
 </TabItem>
+<TabItem value="gitlab" label="GitLab">
 
-<TabItem value="Gitlab" label="Gitlab">
+```yaml
+global:
+  host: devportal.example.com   # your DNS hostname
+  protocol: https
+  port: ''
 
-1. Copy this values.yaml file:
-    
-    ```yaml
-    replicas: 1
+upstream:
+  enabled: true
+  ingress:
+    enabled: true
+    className: nginx             # or 'kong'
+    tls:
+      - secretName: devportal-tls
+        hosts:
+          - devportal.example.com
+  backstage:
     image:
-      repository: veecode/devportal-bundle
-      tag: latest
-      pullPolicy: IfNotPresent
-    
-    environment: development
-    
-    service:
-      enabled: true
-      name: devportal
-      type: ClusterIP
-      containerPort: 7007
-    
-    ingress:
-      enabled: true
-      host: <devportal-host> #devportal.com
-      className: nginx
-      # className: kong
-      # annotations:
-      #   konghq.com/https-redirect-status-code: "308"
-      #   konghq.com/preserve-host: "true"
-      #   konghq.com/protocols: "https"
-      #   konghq.com/strip-path: "false"
-      tls:
-        secretName: devportal-secret
-    
-    resources:
-      requests:
-        cpu: 500m
-        memory: 512Mi
-      limits:
-        cpu: 1000m
-        memory: 1Gi
-    
+      repository: veecode/devportal
+      tag: "1.4.5"
+    extraEnvVarsSecret: devportal-secrets
     appConfig:
-      title: Devportal
       app:
-        baseUrl: <devportal-host>
+        title: "VeeCode DevPortal"
       backend:
-        baseUrl: <devportal-host>
-        secret: 56616a93-ac28-42ab-929d-6ec1fc008c54
-      database:
-        client: pg
-        connection:
-          host: <database-url>
-          port: 5432
-          database: platform_devportal
-          user: <username>
-          password: <password>
-    
-    auth: {}
-    
-    integrations:
-      gitlab:
-        token: <gitlab-token>
-    
-    catalog:
-      providers:
+        database:
+          client: pg
+          connection:
+            host: <db-host>
+            port: 5432
+            database: platform_devportal
+            user: <db-user>
+            password: <db-password>
+      integrations:
         gitlab:
-          branch: main # Optional. Uses `master` as default
-          group: <gitlab group/subgroup> # Optional. Group and subgroup (if needed) to look for repositories. If not present the whole project will be scanned
-          entityFilename: catalog-info.yaml # Optional. Defaults to `catalog-info.yaml`
-          projectPattern: <repository-name> #suggestion devportal-catalog
-    
-    platform:
-      guest:
-        enabled: true
-      apiManagement:
-        enabled: false
-        readOnlyMode: false
-    ```
-    
-2. **Replace `<devportal-host>`**: You'll see this in two places: once under **`ingress.host`** and twice under **`appConfig`**. This should be replaced with the hostname where you will be accessing your DevPortal. It would typically be the domain name or IP address where your DevPortal service will be accessible. For example, it could be **`devportal.yourcompany.com`**.
-3. **Update Database Connection**: In the **`appConfig.database.connection`** section, replace:
-    - **`<database-url>`**: Replace it with the hostname of your PostgreSQL database server.
-    - **`<username>`** and **`<password>`**: Replace these with the credentials used to access your PostgreSQL database.
-4. **Set GitLab Token**: In the **`integrations.gitlab`** section, replace **`<gitlab-token>`** with the GitLab personal access token you created earlier.
-5. **Configure Catalog Repository**: In the **`catalog.providers.gitlab`** section:
-    - Replace **`<gitlab group/subgroup>`**: This is the group or subgroup in GitLab where your repository exists. If your repository is under a subgroup, it should be formatted as **`group/subgroup`**.
-    - Replace **`<repository-name>`**: This should be replaced with the name of your GitLab repository.
+          - host: gitlab.com    # or your self-hosted hostname
+            token: ${GITLAB_TOKEN}
+      auth:
+        providers:
+          gitlab:
+            development:
+              clientId: ${GITLAB_AUTH_CLIENT_ID}
+              clientSecret: ${GITLAB_AUTH_CLIENT_SECRET}
+      catalog:
+        providers:
+          gitlab:
+            myGroup:
+              host: gitlab.com
+              group: <your-gitlab-group>
+              branch: main
+              entityFilename: catalog-info.yaml
+```
 
 </TabItem>
 </Tabs>
 
-1. Open a terminal in the same directory as the YAML file.
-2. Add the Veecode Platform repository to Helm by executing the following command:
-    
-    ```
-    helm repo add veecode-platform https://veecode-platform.github.io/public-charts/
-    ```
-    
-    This command enables Helm to access charts from the Veecode Platform repository.
-    
-3. Update Helm with the latest chart versions from all your repositories:
-    
-    ```
-    helm repo update
-    ```
-    
-    This command retrieves the latest version information about all the charts from the repositories that Helm is aware of.
-    
-4. After successfully completing the steps above, you can install or upgrade the Devportal platform using the following command:
-    
-    ```
-    helm upgrade platform-devportal --install --values ./values.yaml veecode-platform/devportal
-    ```
-    
-    This command upgrades (or installs if it does not exist) the platform-devportal release with the configuration specified in the **`values.yaml`** file. The chart used is from the veecode-platform repository, specifically the **`devportal`** chart.
-    
+Replace all `<placeholder>` values with your actual configuration. Database credentials can also be supplied via a Kubernetes Secret and `extraEnvVarsSecret` instead of inline values.
 
-By following these steps, Helm is properly configured with the Veecode Platform repository and updated with the latest chart information before upgrading or installing the Devportal platform.
+---
 
-:::info Disclaimer
-If you're interested in a deeper understanding of the DevPortal chart, visit the documentation on Artifact Hub, [click here](https://artifacthub.io/packages/helm/veecode-platform/devportal). 
-:::
+## Step 4: Deploy with Helm
 
-## **Step 3: Accessing the DevPortal**
+```bash
+helm repo add veecode-devportal https://veecode-platform.github.io/next-charts
+helm repo update veecode-devportal
+helm upgrade --install veecode-devportal \
+  --namespace platform \
+  --create-namespace \
+  --values values.yaml \
+  veecode-devportal/veecode-devportal
+```
 
-Once the DevPortal deployment is completed, you can access it by following this step:
+---
 
-1. **Open your web browser and navigate to the DevPortal host.**
+## Step 5: Access the portal
 
-You should now have full access to the VeeCode Platform DevPortal and be able to explore its features.
+Once the rollout completes, open `https://devportal.example.com` in your browser. You should reach the DevPortal login screen.
 
-## **Conclusion**
+```bash
+kubectl rollout status deployment/veecode-devportal -n platform
+```
 
-Congratulations! You have successfully installed the VeeCode Platform DevPortal. By following this product installation guide, you have set up the DevPortal on your cluster and can now begin to use.
+---
 
-If you encounter any issues during the installation process, please reach out to the [support team](https://platform.vee.codes/contact-us/) for assistance or join our [community](https://github.com/orgs/veecode-platform/discussions).
+## Next steps
+
+- Configure additional integrations and plugins — see the [Auth & Integrations](/devportal/integrations) section.
+- Review RBAC roles (`role:default/admin`, `role:default/developer`, `role:default/viewer`) and assign them to users.
+- For a deeper explanation of chart keys, see [Understand the Helm Chart](../understand-chart) or the [chart page on ArtifactHub](https://artifacthub.io/packages/helm/veecode-platform-next/veecode-devportal).
+
+If you encounter issues, reach out via [support](https://platform.vee.codes/contact-us/) or join the [community](https://github.com/orgs/veecode-platform/discussions).

--- a/devportal/installation-guide/simple-setup/configure-git-integrations.md
+++ b/devportal/installation-guide/simple-setup/configure-git-integrations.md
@@ -14,9 +14,114 @@ Our documentation is still in progress and we currently provide information on i
 
 ## Choose your provider
 
-Follow the detailed setup instructions for your Git provider in the [Auth & Integrations](/devportal/integrations/integrations) section:
+Follow the detailed setup instructions for your Git provider in the [Auth & Integrations](/devportal/integrations) section:
 
-- [GitHub](/devportal/integrations/github/github) — authentication, backend integrations, and personal access tokens
-- GitLab — coming soon
+- [GitHub](/devportal/integrations/GitHub/) — authentication, backend integrations, and personal access tokens
+- [GitLab](#gitlab) — backend integration via personal access token
 
 Once you have your credentials configured, add the corresponding values to your `values.yaml` file under `upstream.backstage.appConfig` and redeploy.
+
+---
+
+## GitHub
+
+See [GitHub integrations](/devportal/integrations/GitHub/) for full details on OAuth apps, GitHub Apps, and PATs. The minimal `values.yaml` snippet for a GitHub backend integration using a PAT is:
+
+```yaml
+upstream:
+  backstage:
+    appConfig:
+      integrations:
+        github:
+          - host: github.com
+            token: ${GITHUB_TOKEN}
+      catalog:
+        providers:
+          github:
+            myOrg:
+              organization: <your-github-org>
+              catalogPath: /catalog-info.yaml
+              filters:
+                branch: main
+```
+
+Provide `GITHUB_TOKEN` (PAT) via an environment variable or a Kubernetes Secret (see [Secrets](#passing-secrets-as-environment-variables) below).
+
+---
+
+## GitLab
+
+To integrate DevPortal with GitLab you need:
+
+- A **GitLab personal access token** with `read_api`, `read_repository` scopes (assigned to `GITLAB_TOKEN`).
+- Your **GitLab host** — use `gitlab.com` for SaaS or your self-hosted hostname.
+- The **group** (and optional subgroup) that contains your repositories.
+
+Add the following to your `values.yaml` under `upstream.backstage.appConfig`:
+
+```yaml
+upstream:
+  backstage:
+    appConfig:
+      integrations:
+        gitlab:
+          - host: ${GITLAB_HOST}        # e.g. gitlab.com
+            token: ${GITLAB_TOKEN}
+      auth:
+        providers:
+          gitlab:
+            development:
+              clientId: ${GITLAB_AUTH_CLIENT_ID}
+              clientSecret: ${GITLAB_AUTH_CLIENT_SECRET}
+      catalog:
+        providers:
+          gitlab:
+            myGroup:
+              host: ${GITLAB_HOST}
+              group: ${GITLAB_GROUP}          # e.g. my-org or my-org/my-subgroup
+              groupPattern: ${GITLAB_GROUP_PATTERN}  # optional regex
+              branch: main
+              entityFilename: catalog-info.yaml
+```
+
+| Environment variable | Purpose |
+|---|---|
+| `GITLAB_HOST` | GitLab hostname (`gitlab.com` or self-hosted) |
+| `GITLAB_TOKEN` | PAT for backend API access |
+| `GITLAB_AUTH_CLIENT_ID` | OAuth App client ID (for sign-in) |
+| `GITLAB_AUTH_CLIENT_SECRET` | OAuth App client secret (for sign-in) |
+| `GITLAB_GROUP` | Root group to scan for catalog entries |
+| `GITLAB_GROUP_PATTERN` | Optional regex to filter group names |
+
+:::info Sign-in vs. integration
+`GITLAB_AUTH_CLIENT_ID` / `GITLAB_AUTH_CLIENT_SECRET` are only required if you want users to **sign in via GitLab OAuth**. If you only need GitLab as a catalog source, `GITLAB_TOKEN` and `GITLAB_HOST` are sufficient.
+:::
+
+### Create a GitLab OAuth Application (for sign-in)
+
+1. Go to **GitLab → User Settings → Applications** (or **Admin Area → Applications** for instance-wide).
+2. Set **Redirect URI** to `https://<your-devportal-host>/api/auth/gitlab/handler/frame`.
+3. Enable scopes: `read_user`, `openid`, `email`, `profile`.
+4. Save and note the **Application ID** (`GITLAB_AUTH_CLIENT_ID`) and **Secret** (`GITLAB_AUTH_CLIENT_SECRET`).
+
+---
+
+## Passing secrets as environment variables
+
+Never commit tokens directly in `values.yaml`. Instead, pass them as environment variables and reference them with `${VAR_NAME}` syntax in `appConfig`, or create a Kubernetes Secret and reference it via `upstream.backstage.extraEnvVarsSecret`:
+
+```yaml
+upstream:
+  backstage:
+    extraEnvVarsSecret: devportal-secrets
+```
+
+Create the secret once in the cluster:
+
+```bash
+kubectl create secret generic devportal-secrets \
+  --namespace platform \
+  --from-literal=GITLAB_TOKEN=<token> \
+  --from-literal=GITLAB_AUTH_CLIENT_ID=<id> \
+  --from-literal=GITLAB_AUTH_CLIENT_SECRET=<secret>
+```

--- a/devportal/installation-guide/simple-setup/create-values-file.md
+++ b/devportal/installation-guide/simple-setup/create-values-file.md
@@ -44,9 +44,9 @@ upstream:
 This will deploy a functional DevPortal with sensible defaults. You can access it at `http://localhost:8000` (or whatever host/port you configure).
 
 :::info
-To enable authentication and full Git provider integration (GitHub, GitLab, etc.), see the [Auth & Integrations](/devportal/integrations/integrations) section. The values for those integrations should be added under `upstream.backstage.appConfig` in your `values.yaml` file.
+To enable authentication and full Git provider integration (GitHub, GitLab, etc.), see the [Auth & Integrations](/devportal/integrations) section. The values for those integrations should be added under `upstream.backstage.appConfig` in your `values.yaml` file.
 :::
 
 ### About the Helm chart
 
-Please check [Understand the Helm Chart](./understand-chart) for more information on the chart structure and available settings. You can also check the chart page on [ArtifactHub](https://artifacthub.io/packages/helm/veecode-platform/devportal).
+Please check [Understand the Helm Chart](../understand-chart) for more information on the chart structure and available settings. You can also check the chart page on [ArtifactHub](https://artifacthub.io/packages/helm/veecode-platform-next/veecode-devportal).

--- a/devportal/installation-guide/simple-setup/simple-setup.md
+++ b/devportal/installation-guide/simple-setup/simple-setup.md
@@ -4,7 +4,7 @@ sidebar_label: Simple setup
 title: Simple setup
 ---
 
-While in the previous [Local Setup](./local-setup) section we have installed VeeCode DevPortal on a local temporary cluster, in this guide we will install it on a real live Kubernetes cluster in the simplest possible way, so other people may try it.
+While in the previous [Local Setup](../vkdr-local/vkdr-setup) section we have installed VeeCode DevPortal on a local temporary cluster, in this guide we will install it on a real live Kubernetes cluster in the simplest possible way, so other people may try it.
 
 This setup is a little more elaborated:
 

--- a/devportal/installation-guide/understand-chart.md
+++ b/devportal/installation-guide/understand-chart.md
@@ -112,7 +112,7 @@ global:
       - dynamic-plugins.default.yaml
 ```
 
-To enable a specific plugin, add it under the includes list or reference a custom manifest. See the [dynamic plugins documentation](/devportal/integrations) for details.
+To enable a specific plugin, add it under the includes list or reference a custom manifest. See the [dynamic plugins documentation](/devportal/concepts/dynamic-plugins) for details.
 
 ## RBAC
 

--- a/devportal/installation-guide/understand-chart.md
+++ b/devportal/installation-guide/understand-chart.md
@@ -6,28 +6,120 @@ title: Understand the Helm Chart
 
 VeeCode DevPortal Helm chart can be used to install and configure our Backstage distribution and a whole set of plugins to provide a full Internal Development Portal experience.
 
-The chart is available on [ArtifactHub](https://artifacthub.io/packages/helm/veecode-platform/devportal) and is mantained in a dedicated [GitHub repository](https://github.com/veecode-platform/next-charts).
+The chart is available on [ArtifactHub](https://artifacthub.io/packages/helm/veecode-platform-next/veecode-devportal) and is maintained in a dedicated [GitHub repository](https://github.com/veecode-platform/next-charts). The full default `values.yaml` is at [`veecode-devportal-chart/values.yaml`](https://github.com/veecode-platform/next-charts/blob/main/veecode-devportal-chart/values.yaml).
 
-## Important sections
+## Chart structure
 
-A few sections are worth some deeper analysis:
+The `veecode-devportal` chart wraps the official [Backstage Helm chart](https://github.com/backstage/charts/tree/main/charts/backstage) as a subchart, aliased as `upstream`. This means:
 
-- **Global settings**
+- All upstream Backstage chart values are available under the `upstream:` key.
+- VeeCode-specific settings (routing shortcuts, plugin manifests, RBAC toggles) live at the top level alongside `upstream`.
+- The `app-config.yaml` content you would normally write as a file maps directly to `upstream.backstage.appConfig` in `values.yaml`.
 
-The `host`, `protocol` and `port` settings define the domain you will use to access the portal:
+## Global settings
+
+The `global` block is a VeeCode convenience layer. Setting these three values propagates them automatically into several Backstage config fields so you don't have to repeat yourself.
 
 ```yaml
 global:
   host: yourhost.yourdomain.com # change to your domain
-  protocol: https # usually https
-  port: '' # must start with ':', defaults to empty
+  protocol: https               # http or https
+  port: ''                      # must start with ':' if not empty, e.g. ':8000'
 ```
 
-They actually work as a convenience to define the default value for several other settings:
+These values are used as defaults for:
 
 - `upstream.backstage.appConfig.app.baseUrl`
 - `upstream.backstage.appConfig.backend.baseUrl`
-- `upstream.backstage.appConfig.backend.cors.baseUrl`
+- `upstream.backstage.appConfig.backend.cors.origin`
 - `upstream.ingress.host`
 
-TODO: add more sections
+## Application config (`upstream.backstage.appConfig`)
+
+Everything that would normally go in `app-config.yaml` is placed here. The chart merges your values with the chart's built-in defaults, so you only need to override what differs from the defaults.
+
+Example — setting the portal title and enabling an ingress:
+
+```yaml
+upstream:
+  enabled: true
+  ingress:
+    enabled: true
+  backstage:
+    appConfig:
+      app:
+        title: "My DevPortal"
+```
+
+For auth providers, integrations, catalog providers, and plugin configuration, nest the relevant Backstage config keys under `upstream.backstage.appConfig`. For example:
+
+```yaml
+upstream:
+  backstage:
+    appConfig:
+      integrations:
+        github:
+          - host: github.com
+            token: ${GITHUB_TOKEN}
+      auth:
+        providers:
+          github:
+            development:
+              clientId: ${GITHUB_AUTH_CLIENT_ID}
+              clientSecret: ${GITHUB_AUTH_CLIENT_SECRET}
+```
+
+## Passing secrets
+
+Tokens and secrets should never be hardcoded in `values.yaml`. Reference them as environment variables (`${MY_VAR}` syntax in `appConfig`) and supply the values via a Kubernetes Secret:
+
+```yaml
+upstream:
+  backstage:
+    extraEnvVarsSecret: devportal-secrets
+```
+
+```bash
+kubectl create secret generic devportal-secrets \
+  --namespace platform \
+  --from-literal=GITHUB_TOKEN=<token>
+```
+
+## Ingress
+
+TLS and ingress class are configured under `upstream.ingress`:
+
+```yaml
+upstream:
+  ingress:
+    enabled: true
+    className: nginx   # or 'kong'
+    annotations: {}
+    tls:
+      - secretName: devportal-tls
+        hosts:
+          - yourhost.yourdomain.com
+```
+
+## Dynamic plugins
+
+Preinstalled VeeCode plugins ship as disabled and are activated at runtime via a plugin manifest. The chart key is:
+
+```yaml
+global:
+  dynamic:
+    includes:
+      - dynamic-plugins.default.yaml
+```
+
+To enable a specific plugin, add it under the includes list or reference a custom manifest. See the [dynamic plugins documentation](/devportal/integrations) for details.
+
+## RBAC
+
+The chart can create cluster roles automatically:
+
+```yaml
+createClusterRoles: true
+```
+
+DevPortal's built-in RBAC roles are `role:default/admin`, `role:default/developer`, and `role:default/viewer`. These are defined in `rbac-policy.csv` inside the image and extended by the distro's `rbac-policy-extensions.csv`.

--- a/devportal/installation-guide/vkdr-local/deployment.md
+++ b/devportal/installation-guide/vkdr-local/deployment.md
@@ -11,7 +11,8 @@ In this step, you will deploy and access **VeeCode DevPortal** in your local env
 In this section, you will:
 
 1. **Check Requirements**: Ensure Docker, Kubernetes, DNS, and GitHub token are ready.
-1. **Deploy DevPortal** into your local cluster with a single `vkdr` command.
+2. **Install Kong Gateway** as the ingress controller.
+3. **Deploy DevPortal** into your local cluster.
 
 By the end, you will have a fully functional DevPortal instance running locally for testing, learning, and development.
 
@@ -26,16 +27,26 @@ Before deploying DevPortal, ensure the following prerequisites are ready:
 
 Once these requirements are in place, you’re ready to deploy DevPortal.
 
-## Step 2: Deploy DevPortal
+## Step 2: Install Kong Gateway
 
-The command `vkdr devportal install` not only installs DevPortal and its dependencies but also **deploys and starts all required services and sample applications** inside the Kubernetes cluster.
+DevPortal requires Kong Gateway as its ingress controller. Install it first:
+
+```sh
+vkdr kong install --default-ic
+```
+
+This installs Kong Gateway and sets it as the default ingress controller for the cluster.
+
+## Step 3: Deploy DevPortal
+
+The command `vkdr devportal install` installs DevPortal and **deploys all required services and sample applications** inside the Kubernetes cluster.
 
 Run:
 
 ```sh
 vkdr devportal install \
   --github-token=$GITHUB_TOKEN \
-  --install-samples
+  --samples
 ```
 
 Expected output (example):
@@ -91,7 +102,7 @@ Open the following URL in your browser:
 
 > http://devportal.localhost:8000
 
-The DevPortal interface should load, confirming that the deployment was successful and the applications are running.
+The DevPortal interface should load, confirming that the deployment was successful and the applications are running. The PetClinic sample app is available at [http://petclinic.localhost:8000](http://petclinic.localhost:8000).
 
 ---
 

--- a/devportal/installation-guide/vkdr-local/github.md
+++ b/devportal/installation-guide/vkdr-local/github.md
@@ -17,12 +17,26 @@ GitHub offers two types of PATs:
 
 Follow this guide to create a **Classic PAT**:
 
-- [Classic PAT](/devportal/integrations/github/github-tokens#classic-pat)
+- [Classic PAT](/devportal/integrations/GitHub/github-tokens#classic-pat)
 
 Follow this guide to create a **Fine-grained PAT**:
 
-- [Fine-grained PAT](/devportal/integrations/github/github-tokens#fine-grained-pat)
+- [Fine-grained PAT](/devportal/integrations/GitHub/github-tokens#fine-grained-pat)
 
 :::tip
 While you are still struggling to understand the permissions and how they relate to core DevPortal features and plugins, you can always create a **Classic PAT**. It is the simplest option and will work for most cases. Make it work and later refine it to a **Fine-grained PAT** for better security and control or, even better, use a **GitHub App** approach.
+:::
+
+## Export the token
+
+Once you have your PAT, export it as an environment variable in your shell session. The deployment command in the next step reads it from `$GITHUB_TOKEN`.
+
+```bash
+export GITHUB_TOKEN=<your-token>
+```
+
+Replace `<your-token>` with the actual token value. This variable must be set in the same shell session where you run `vkdr devportal install`.
+
+:::caution
+Do not commit your token to version control. If you need this token to persist across shell sessions, add the `export` line to your shell profile (e.g., `~/.bashrc` or `~/.zshrc`) and restrict the file's read permissions.
 :::

--- a/devportal/installation-guide/vkdr-local/infra.md
+++ b/devportal/installation-guide/vkdr-local/infra.md
@@ -31,7 +31,7 @@ Expected output (example):
 VKDR Local Infra Start Routine
 Ports Used: 8000/http :8001/https
 Kubernetes API port: random
-Local Docker Hub Registry Mirror: 6001
+Local Docker Hub Registry Mirror: 6000
 INFO: Creating Kubernetes nodes and registries...
 INFO: Starting LoadBalancer and tools node...
 INFO: Cluster 'vkdr-local' created successfully!
@@ -43,7 +43,7 @@ After this step, the following will be available:
 
 - A local Kubernetes cluster running under Docker.
 - Ports **8000** and **8001** bound to HTTP and HTTPS of the first LoadBalancer in the cluster (DevPortal will configure this automatically).
-- Local **registry mirrors** (starting from port 6001) to speed up Docker image downloads, even when recycling the cluster.
+- Local **registry mirrors** (starting from port 6000) to speed up Docker image downloads, even when recycling the cluster.
 
 ### Check Cluster Status
 
@@ -77,16 +77,16 @@ To access DevPortal and other services in your local cluster, you need friendly 
 Run the following command (or edit your hosts file manually):
 
 ```sh
-echo "127.0.0.1 devportal.localhost manager.localhost" | sudo tee -a /etc/hosts
+echo "127.0.0.1 devportal.localhost manager.localhost petclinic.localhost" | sudo tee -a /etc/hosts
 ```
 
 Expected result (example):
 
 ```sh
-127.0.0.1 devportal.localhost manager.localhost
+127.0.0.1 devportal.localhost manager.localhost petclinic.localhost
 ```
 
-This maps `devportal.localhost` and `manager.localhost` to your local machine, so you can open DevPortal in a browser as usual.
+This maps `devportal.localhost`, `manager.localhost`, and `petclinic.localhost` to your local machine, so you can open DevPortal and sample applications in a browser as usual.
 
 ### Check Host Entries
 
@@ -113,7 +113,7 @@ ping -c 1 manager.localhost
 Expected output (example):
 
 ```sh
-PING devportal.localhost (127.0.0.1): 56 data bytes
+PING manager.localhost (127.0.0.1): 56 data bytes
 64 bytes from 127.0.0.1: icmp_seq=0 ttl=64 time=0.093 ms
 ...
 ```

--- a/devportal/installation-guide/vkdr-local/requirements.md
+++ b/devportal/installation-guide/vkdr-local/requirements.md
@@ -43,10 +43,6 @@ Bash is available
 
 > Note: The command only checks if Bash is installed somewhere on your system. You do not need to switch your current shell to Bash.
 
-Aqui está a seção revisada, incluindo instruções para **rodar o Docker** de forma simples e didática:
-
----
-
 ## Step 2: Docker Engine
 
 Docker is required because DevPortal runs inside containers. You will also use Docker indirectly through `k3d`, which launches a Kubernetes cluster inside Docker.

--- a/devportal/integrations/Azure/_category_.json
+++ b/devportal/integrations/Azure/_category_.json
@@ -1,0 +1,4 @@
+{
+    "label": "Azure / Microsoft",
+    "position": 4
+  }

--- a/devportal/integrations/Azure/azure.md
+++ b/devportal/integrations/Azure/azure.md
@@ -1,0 +1,160 @@
+---
+sidebar_position: 1
+sidebar_label: Azure / Microsoft
+title: Azure / Microsoft Auth & Integrations
+---
+
+The `azure` profile connects VeeCode DevPortal to Microsoft Azure AD (Entra ID) for user sign-in via OIDC, Azure DevOps for repository catalog ingestion, and Microsoft Graph for org sync (users and groups).
+
+## Overview
+
+- **Authentication**: Users sign in with their Microsoft accounts via OIDC.
+- **Azure DevOps integration**: The catalog discovers `catalog-info.yaml` files across repositories using Azure DevOps Code Search.
+- **Org sync**: Microsoft Graph ingests Azure AD users and groups as Backstage `User` and `Group` entities.
+
+## Profile
+
+Set `VEECODE_PROFILE=azure` to activate `app-config.azure.yaml`.
+
+## Required environment variables
+
+| Variable | Description |
+|---|---|
+| `AZURE_CLIENT_ID` | Azure AD App Registration client ID |
+| `AZURE_CLIENT_SECRET` | Azure AD App Registration client secret |
+| `AZURE_TENANT_ID` | Azure AD tenant ID |
+| `AZURE_ORGANIZATION` | Azure DevOps organization name |
+| `AZURE_PROJECT` | Azure DevOps project name (use `*` for all projects) |
+| `AZURE_TOKEN` | Azure DevOps Personal Access Token (for integration) |
+| `AUTH_SESSION_SECRET` | Random secret for server-side session cookies |
+
+## Prerequisites
+
+1. An Azure AD App Registration with:
+   - **Redirect URI**: `https://<your-instance>/api/auth/microsoft/handler/frame`
+   - **API permissions**: `User.Read`, `email`, `openid`, `profile` (for sign-in); `User.Read.All`, `Group.Read.All`, `GroupMember.Read.All` (for org sync via MS Graph)
+2. An Azure DevOps PAT with **Code (Read)** scope (required for repo discovery). The [Azure DevOps Code Search extension](https://marketplace.visualstudio.com/items?itemName=ms.vss-code-search) must be installed in your organization.
+
+## Step 1: Create an Azure AD App Registration
+
+1. Go to [Azure Portal → App registrations](https://portal.azure.com/#blade/Microsoft_AAD_IAM/ActiveDirectoryMenuBlade/RegisteredApps).
+2. Click **New registration**.
+3. Set the redirect URI to `https://<your-instance>/api/auth/microsoft/handler/frame` (type: Web).
+4. Go to **Certificates & secrets → New client secret** and copy the secret value.
+5. Note the **Application (client) ID** and **Directory (tenant) ID**.
+6. Under **API permissions**, grant the required permissions and click **Grant admin consent**.
+
+## Step 2: Configure auth and integration
+
+```yaml
+signInPage: microsoft
+
+auth:
+  session:
+    secret: ${AUTH_SESSION_SECRET}
+    cookieName: backstage-auth-session
+    sameSite: lax
+    secure: false
+  environment: development
+  providers:
+    microsoft:
+      development:
+        clientId: "${AZURE_CLIENT_ID}"
+        clientSecret: "${AZURE_CLIENT_SECRET}"
+        tenantId: "${AZURE_TENANT_ID}"
+        signIn:
+          resolvers:
+            - resolver: emailMatchingUserEntityProfileEmail
+            - resolver: emailLocalPartMatchingUserEntityName
+
+integrations:
+  azure:
+    - host: dev.azure.com
+      credentials:
+        - personalAccessToken: ${AZURE_TOKEN}
+```
+
+:::tip
+The integration also supports service principal credentials (`clientId`, `clientSecret`, `tenantId`) as an alternative to a PAT. The PAT form is shown here as it is the most common starting point.
+:::
+
+## Step 3: Configure catalog discovery and org sync
+
+```yaml
+catalog:
+  providers:
+    # Azure DevOps repo discovery — requires Code Search extension
+    azureDevOps:
+      microsoft:
+        organization: "${AZURE_ORGANIZATION}"
+        project: "${AZURE_PROJECT}"
+        repository: "*"
+        path: "/catalog-info.yaml"
+        schedule:
+          frequency:
+            minutes: 2
+          initialDelay:
+            seconds: 15
+          timeout:
+            minutes: 10
+
+    # Microsoft Graph org sync
+    microsoftGraphOrg:
+      default:
+        tenantId: ${AZURE_TENANT_ID}
+        user:
+          filter: accountEnabled eq true and userType eq 'member'
+        group:
+          filter: startsWith(displayName,'backstage-')
+        schedule:
+          frequency: PT1H
+          timeout: PT50M
+```
+
+:::note
+The `group.filter` above ingests only groups whose display name starts with `backstage-`. Adjust this filter to match your organization's group naming convention.
+:::
+
+## Permission (RBAC) group mapping
+
+The live config pre-maps `group:default/backstage-admins` to the admin and superUser roles:
+
+```yaml
+permission:
+  rbac:
+    admin:
+      users:
+        - name: group:default/backstage-admins
+      superUsers:
+        - name: group:default/backstage-admins
+```
+
+Rename `backstage-admins` to match the group synced from Azure AD that should hold admin access.
+
+## Quick start
+
+```bash
+docker run -p 7007:7007 \
+  -e VEECODE_PROFILE=azure \
+  -e AZURE_CLIENT_ID=<client-id> \
+  -e AZURE_CLIENT_SECRET=<client-secret> \
+  -e AZURE_TENANT_ID=<tenant-id> \
+  -e AZURE_ORGANIZATION=<devops-org> \
+  -e AZURE_PROJECT="*" \
+  -e AZURE_TOKEN=<pat> \
+  -e AUTH_SESSION_SECRET=<random-secret> \
+  veecode/devportal:latest
+```
+
+## Troubleshooting
+
+- **Redirect URI mismatch**: The URI registered in Azure must match `https://<your-instance>/api/auth/microsoft/handler/frame` exactly (including scheme and path).
+- **MS Graph groups not ingesting**: Ensure the App Registration has `Group.Read.All` and `GroupMember.Read.All` permissions with admin consent granted.
+- **Azure DevOps catalog empty**: Install the [Code Search extension](https://marketplace.visualstudio.com/items?itemName=ms.vss-code-search) in your organization and verify `AZURE_TOKEN` has **Code (Read)** scope.
+- **Session errors**: `AUTH_SESSION_SECRET` must be set and stable across restarts; changing it invalidates all existing sessions.
+
+## References
+
+- [Backstage Microsoft Auth Provider](https://backstage.io/docs/auth/microsoft/provider/)
+- [Backstage Azure DevOps Integration](https://backstage.io/docs/integrations/azure/org/)
+- [Azure AD App Registrations](https://learn.microsoft.com/en-us/azure/active-directory/develop/quickstart-register-app)

--- a/devportal/integrations/GitHub/github-auth.md
+++ b/devportal/integrations/GitHub/github-auth.md
@@ -93,8 +93,17 @@ auth:
   providers:
     github:
       development:
-        clientId: ${AUTH_GITHUB_CLIENT_ID}
-        clientSecret: ${AUTH_GITHUB_CLIENT_SECRET}
+        clientId: ${GITHUB_AUTH_CLIENT_ID}
+        clientSecret: ${GITHUB_AUTH_CLIENT_SECRET}
+        signIn:
+          resolvers:
+            - resolver: usernameMatchingUserEntityName
+            - resolver: emailMatchingUserEntityProfileEmail
+            - resolver: emailLocalPartMatchingUserEntityName
+        scope:
+          - read:user
+          - user:email
+          - read:org
 ```
 
 :::tip
@@ -142,8 +151,17 @@ auth:
   providers:
     github:
       development:
-        clientId: ${AUTH_GITHUB_CLIENT_ID}
-        clientSecret: ${AUTH_GITHUB_CLIENT_SECRET}
+        clientId: ${GITHUB_AUTH_CLIENT_ID}
+        clientSecret: ${GITHUB_AUTH_CLIENT_SECRET}
+        signIn:
+          resolvers:
+            - resolver: usernameMatchingUserEntityName
+            - resolver: emailMatchingUserEntityProfileEmail
+            - resolver: emailLocalPartMatchingUserEntityName
+        scope:
+          - read:user
+          - user:email
+          - read:org
 ```
 
 ## About VeeCode Profiles
@@ -157,7 +175,7 @@ You will find more information about VeeCode Profiles in:
 ## Troubleshooting
 
 - **Callback URL Mismatch**: Ensure the callback URL in your GitHub OAuth app matches exactly with your VeeCode DevPortal URL.
-- **Insufficient Permissions**: Verify that the OAuth app has the required scopes (`read:user`, `user:email`).
+- **Insufficient Permissions**: Verify that the OAuth app has the required scopes (`read:user`, `user:email`, `read:org`). Missing `read:org` prevents org/team resolution.
 - **Rate Limiting**: Consider using GitHub App authentication for higher rate limits.
 
 ## Security Considerations

--- a/devportal/integrations/GitHub/github-integrations.md
+++ b/devportal/integrations/GitHub/github-integrations.md
@@ -83,7 +83,7 @@ To create a GitHub App for backend integrations:
 3. Fill in the application details:
    - **GitHub App name**: VeeCode DevPortal Integration
    - **Homepage URL**: `https://your-veecode-instance.com`
-   - **Authorization callback URL**: `https://your-veecode-instance.com/api/auth/github/handler/frame`
+   - **Authorization callback URL**: `https://your-veecode-instance.com/api/auth/github/handler/frame` — only required if this same GitHub App also handles sign-in. For an integration-only App (the recommended setup, where an OAuth App handles sign-in), this can be left blank.
    - **Permissions** (read more at [Required GitHub App Permissions](./github-integrations.md#required-github-app-permissions)):
      - Repository Permissions
         - Actions: Read and Write

--- a/devportal/integrations/GitHub/github-integrations.md
+++ b/devportal/integrations/GitHub/github-integrations.md
@@ -16,7 +16,9 @@ GitHub backend integrations enable VeeCode DevPortal to interact with GitHub API
 These integrations run server-side and use **service credentials** rather than end-user tokens.
 
 :::tip
-If you use the `github` or `github-pat` profiles, DevPortal will configure both authentication and integrations for you using bundled `app-config.yaml` files. You still need to obtain the GitHub App and PAT credentials manually and provide the environment variables, though.
+If you use the `github` profile, DevPortal will configure both authentication and integrations for you using a bundled `app-config.yaml` file. You still need to obtain the GitHub App and PAT credentials manually and provide the environment variables, though.
+
+The `github-pat` profile configures **integrations and org sync only** (with guest/no authentication). It does not configure the auth provider and is intended for local development and PoCs. See [GitHub Tokens](./github-tokens.md) for the required `GITHUB_TOKEN` variable.
 :::
 
 ## How Backend Integrations Work
@@ -123,10 +125,9 @@ integrations:
         - appId: ${GITHUB_APP_ID}
           clientId: ${GITHUB_CLIENT_ID}
           clientSecret: ${GITHUB_CLIENT_SECRET}
-          webhookUrl: ${GITHUB_WEBHOOK_URL}
-          webhookSecret: ${GITHUB_WEBHOOK_SECRET}
           privateKey: |
             ${GITHUB_PRIVATE_KEY}
+          # webhookSecret: ${GITHUB_WEBHOOK_SECRET}  # optional — only for webhook event handling
 ```
 
 :::warning
@@ -143,8 +144,10 @@ integrations:
     - host: github.com
       apps:
         - appId: ${GITHUB_APP_ID}
-          privateKey: ${GITHUB_PRIVATE_KEY}
-          # ... other app config
+          clientId: ${GITHUB_CLIENT_ID}
+          clientSecret: ${GITHUB_CLIENT_SECRET}
+          privateKey: |
+            ${GITHUB_PRIVATE_KEY}
       token: ${GITHUB_TOKEN}  # Fallback PAT
 ```
 

--- a/devportal/integrations/GitHub/github-integrations.md
+++ b/devportal/integrations/GitHub/github-integrations.md
@@ -18,7 +18,7 @@ These integrations run server-side and use **service credentials** rather than e
 :::tip
 If you use the `github` profile, DevPortal will configure both authentication and integrations for you using a bundled `app-config.yaml` file. You still need to obtain the GitHub App and PAT credentials manually and provide the environment variables, though.
 
-The `github-pat` profile configures **integrations and org sync only** (with guest/no authentication). It does not configure the auth provider and is intended for local development and PoCs. See [GitHub Tokens](./github-tokens.md) for the required `GITHUB_TOKEN` variable.
+The `github-pat` profile configures **repository/catalog discovery and integrations only** (with guest/no authentication). It uses the `github` catalog provider to ingest `catalog-info.yaml` entities from the organization's repos — it does **not** import GitHub users and teams as `User`/`Group` entities (that org sync is the `githubOrg` provider, configured by the full `github` profile). It also does not configure the auth provider, and is intended for local development and PoCs. See [GitHub Tokens](./github-tokens.md) for the required `GITHUB_TOKEN` variable.
 :::
 
 ## How Backend Integrations Work

--- a/devportal/integrations/GitLab/_category_.json
+++ b/devportal/integrations/GitLab/_category_.json
@@ -1,0 +1,4 @@
+{
+    "label": "GitLab",
+    "position": 3
+  }

--- a/devportal/integrations/GitLab/gitlab-auth.md
+++ b/devportal/integrations/GitLab/gitlab-auth.md
@@ -1,0 +1,119 @@
+---
+sidebar_position: 2
+sidebar_label: GitLab Auth & Integration
+title: GitLab Authentication & Integration
+---
+
+## Prerequisites
+
+1. A GitLab account with owner access to your group or instance.
+2. Decide whether you are using **GitLab.com** (SaaS) or a **self-hosted GitLab** instance.
+
+## Step 1: Create a GitLab OAuth application
+
+1. Go to your group or user **Settings → Applications** (for a self-hosted instance, you can also use the admin area).
+2. Fill in:
+   - **Name**: VeeCode DevPortal
+   - **Redirect URI**: `https://<your-instance>/api/auth/gitlab/handler/frame`
+   - **Scopes**: `read_user`, `openid`, `profile`, `email`
+3. Save the application and note the **Application ID** and **Secret**.
+
+## Step 2: Create a Group or Personal Access Token (integration)
+
+The backend integration requires a token with `read_api` scope so the catalog and scaffolder can read repository data.
+
+1. Go to **User Settings → Access Tokens** (or a group's **Settings → Access Tokens** for a group token).
+2. Select scopes: `read_api` (and `write_repository` if scaffolder needs to create branches/PRs).
+3. Save the token — you will not see it again.
+
+## Step 3: Configure auth and integration
+
+Add the following to your `app-config.yaml` (or pass via environment variables):
+
+```yaml
+signInPage: gitlab
+
+auth:
+  environment: development
+  providers:
+    gitlab:
+      development:
+        clientId: ${GITLAB_AUTH_CLIENT_ID}
+        clientSecret: ${GITLAB_AUTH_CLIENT_SECRET}
+        # For self-hosted GitLab, uncomment and set your instance URL:
+        # audience: https://${GITLAB_HOST}
+        signIn:
+          resolvers:
+            - resolver: usernameMatchingUserEntityName
+            - resolver: emailMatchingUserEntityProfileEmail
+            - resolver: emailLocalPartMatchingUserEntityName
+
+integrations:
+  gitlab:
+    - host: ${GITLAB_HOST}
+      token: ${GITLAB_TOKEN}
+```
+
+:::note
+The `audience` field is only required for self-hosted instances. For `gitlab.com`, it can be omitted.
+:::
+
+## Step 4: Configure org sync (catalog provider)
+
+Org sync ingests groups and users from a root GitLab group into the Backstage catalog.
+
+```yaml
+catalog:
+  providers:
+    gitlab:
+      default:
+        host: ${GITLAB_HOST}
+        group: ${GITLAB_GROUP}
+        orgEnabled: true
+        restrictUsersToGroup: true
+        includeUsersWithoutSeat: true
+        relations:
+          - INHERITED
+          - DESCENDANTS
+          - SHARED_FROM_GROUPS
+        groupPattern: ${GITLAB_GROUP_PATTERN}
+        branch: main
+        fallbackBranch: master
+        skipForkedRepos: false
+        entityFilename: catalog-info.yaml
+        rules:
+          - allow: [Group, User]
+        schedule:
+          frequency:
+            minutes: 5
+          timeout:
+            minutes: 3
+```
+
+## Using the `gitlab` profile
+
+Set `VEECODE_PROFILE=gitlab` and provide the required env vars. DevPortal loads the pre-bundled `app-config.gitlab.yaml` which includes all sections above.
+
+```bash
+docker run -p 7007:7007 \
+  -e VEECODE_PROFILE=gitlab \
+  -e GITLAB_HOST=gitlab.com \
+  -e GITLAB_AUTH_CLIENT_ID=<app-id> \
+  -e GITLAB_AUTH_CLIENT_SECRET=<app-secret> \
+  -e GITLAB_TOKEN=<access-token> \
+  -e GITLAB_GROUP=<root-group> \
+  veecode/devportal:latest
+```
+
+## Troubleshooting
+
+- **Callback URL mismatch**: The redirect URI in your GitLab application must match `https://<your-instance>/api/auth/gitlab/handler/frame` exactly.
+- **Sign-in resolvers failing**: Ensure users in the catalog have `spec.profile.email` or `metadata.name` matching their GitLab username. The three resolvers are tried in order; the first match wins.
+- **Catalog not ingesting repos**: Verify the `GITLAB_TOKEN` has `read_api` scope and is scoped to the correct group.
+- **Self-hosted instance**: Set `audience: https://${GITLAB_HOST}` in the auth provider config. Without it, token validation may fail.
+
+## References
+
+- [Backstage GitLab Auth Provider](https://backstage.io/docs/auth/gitlab/provider/)
+- [Backstage GitLab Integration](https://backstage.io/docs/integrations/gitlab/locations/)
+- [GitLab OAuth Applications](https://docs.gitlab.com/ee/integration/oauth_provider.html)

--- a/devportal/integrations/GitLab/gitlab.md
+++ b/devportal/integrations/GitLab/gitlab.md
@@ -1,0 +1,88 @@
+---
+sidebar_position: 1
+sidebar_label: GitLab
+title: GitLab Auth & Integrations
+---
+
+GitLab is a supported identity and SCM provider in VeeCode DevPortal. When you use the `gitlab` profile, DevPortal configures GitLab OAuth authentication, the GitLab integration token for backend operations, and GitLab group-based org sync.
+
+## Overview
+
+VeeCode DevPortal interacts with GitLab in two distinct ways:
+
+- **[Authentication](./gitlab-auth.md)**: Users sign in with their GitLab accounts via OAuth 2.0.
+- **Backend integrations**: The DevPortal backend (catalog, scaffolder, plugins) accesses GitLab APIs using a Personal or Group Access Token.
+
+Org sync ingests GitLab groups and their members as Backstage `Group` and `User` catalog entities.
+
+## Profile
+
+Set `VEECODE_PROFILE=gitlab` to activate the pre-bundled `app-config.gitlab.yaml` configuration.
+
+## Required environment variables
+
+| Variable | Description |
+|---|---|
+| `GITLAB_HOST` | GitLab hostname (e.g., `gitlab.com` or `gitlab.example.com`) |
+| `GITLAB_AUTH_CLIENT_ID` | OAuth Application ID (for sign-in) |
+| `GITLAB_AUTH_CLIENT_SECRET` | OAuth Application Secret |
+| `GITLAB_TOKEN` | Personal or Group Access Token (`read_api` scope, for integrations) |
+| `GITLAB_GROUP` | Root group for org sync and repo discovery (e.g., `my-org`) |
+
+## Optional environment variables
+
+| Variable | Default | Description |
+|---|---|---|
+| `GITLAB_GROUP_PATTERN` | `[\s\S]*` | Pattern to match sub-groups for catalog sync |
+
+## Decision tree
+
+```mermaid
+flowchart TD
+    A[DevPortal makes a GitLab call] --> B{Which context?}
+
+    B -->|User sign-in| C[OAuth 2.0 via GitLab application]
+    C --> D[Uses GITLAB_AUTH_CLIENT_ID / SECRET]
+
+    B -->|Backend: catalog / scaffolder / plugins| E[GitLab integration]
+    E --> F[Uses GITLAB_TOKEN]
+```
+
+## Quick start
+
+### Minimal `docker run`
+
+```bash
+docker run -p 7007:7007 \
+  -e VEECODE_PROFILE=gitlab \
+  -e GITLAB_HOST=gitlab.com \
+  -e GITLAB_AUTH_CLIENT_ID=<your-client-id> \
+  -e GITLAB_AUTH_CLIENT_SECRET=<your-client-secret> \
+  -e GITLAB_TOKEN=<your-access-token> \
+  -e GITLAB_GROUP=<your-root-group> \
+  veecode/devportal:latest
+```
+
+### Docker Compose
+
+```yaml
+services:
+  devportal:
+    image: veecode/devportal:latest
+    ports:
+      - "7007:7007"
+    environment:
+      VEECODE_PROFILE: gitlab
+      GITLAB_HOST: gitlab.com
+      GITLAB_AUTH_CLIENT_ID: ${GITLAB_AUTH_CLIENT_ID}
+      GITLAB_AUTH_CLIENT_SECRET: ${GITLAB_AUTH_CLIENT_SECRET}
+      GITLAB_TOKEN: ${GITLAB_TOKEN}
+      GITLAB_GROUP: ${GITLAB_GROUP}
+      GITLAB_GROUP_PATTERN: "[\\.\\s\\S]*"
+```
+
+## References
+
+- [GitLab Auth & Configuration](./gitlab-auth.md)
+- [Backstage GitLab Auth Provider](https://backstage.io/docs/auth/gitlab/provider/)
+- [Backstage GitLab Integration](https://backstage.io/docs/integrations/gitlab/locations/)

--- a/devportal/integrations/Keycloak/_category_.json
+++ b/devportal/integrations/Keycloak/_category_.json
@@ -1,0 +1,4 @@
+{
+    "label": "Keycloak",
+    "position": 5
+  }

--- a/devportal/integrations/Keycloak/keycloak-auth.md
+++ b/devportal/integrations/Keycloak/keycloak-auth.md
@@ -1,0 +1,153 @@
+---
+sidebar_position: 1
+sidebar_label: Keycloak Auth
+title: Keycloak Authentication & Org Sync
+---
+
+The `keycloak` profile connects VeeCode DevPortal to a Keycloak instance for OIDC-based user sign-in and realm-based org sync (users and groups).
+
+## Overview
+
+- **Authentication**: Users sign in via OIDC using a Keycloak realm. The `oidc` Backstage auth provider handles the flow.
+- **Org sync**: The `keycloakOrg` catalog provider ingests realm users and groups as Backstage `User` and `Group` entities.
+
+## Profile
+
+Set `VEECODE_PROFILE=keycloak` to activate `app-config.keycloak.yaml`.
+
+The entrypoint automatically derives `KEYCLOAK_METADATA_URL` as `${KEYCLOAK_BASE_URL}/realms/${KEYCLOAK_REALM}` if it is not explicitly set.
+
+## Required environment variables
+
+| Variable | Description |
+|---|---|
+| `KEYCLOAK_BASE_URL` | Base URL of the Keycloak server (e.g., `https://keycloak.example.com`) |
+| `KEYCLOAK_REALM` | Name of the Keycloak realm |
+| `KEYCLOAK_CLIENT_ID` | Client ID configured in Keycloak |
+| `KEYCLOAK_CLIENT_SECRET` | Client secret for the Keycloak client |
+| `AUTH_SESSION_SECRET` | Random secret for server-side session cookies |
+
+## Optional environment variables
+
+| Variable | Default | Description |
+|---|---|---|
+| `KEYCLOAK_METADATA_URL` | `${KEYCLOAK_BASE_URL}/realms/${KEYCLOAK_REALM}` | OIDC discovery endpoint (derived automatically if not set) |
+
+## Prerequisites
+
+1. A Keycloak realm configured for your organization.
+2. A Keycloak client with:
+   - **Client protocol**: `openid-connect`
+   - **Access type**: `confidential`
+   - **Valid redirect URIs**: `https://<your-instance>/api/auth/oidc/handler/frame`
+   - **Standard Flow Enabled**: yes
+   - **Service Accounts Enabled**: yes (required for org sync)
+   - **Client roles** or realm roles granting `view-users` and `query-groups` to the service account.
+
+## Step 1: Configure auth
+
+```yaml
+signInPage: keycloak
+
+auth:
+  session:
+    secret: ${AUTH_SESSION_SECRET}
+    cookieName: backstage-auth-session
+    sameSite: lax
+    secure: false
+  environment: development
+  providers:
+    oidc:
+      development:
+        metadataUrl: ${KEYCLOAK_BASE_URL}/realms/${KEYCLOAK_REALM}
+        clientId: ${KEYCLOAK_CLIENT_ID}
+        clientSecret: ${KEYCLOAK_CLIENT_SECRET}
+        prompt: auto
+        signIn:
+          resolvers:
+            - resolver: oidcSubClaimMatchingKeycloakUserId
+            - resolver: preferredUsernameMatchingUserEntityName
+            - resolver: emailMatchingUserEntityProfileEmail
+            - resolver: emailLocalPartMatchingUserEntityName
+```
+
+### Sign-in resolvers
+
+The resolvers are tried in order; the first match establishes the Backstage identity:
+
+| Resolver | What it matches |
+|---|---|
+| `oidcSubClaimMatchingKeycloakUserId` | OIDC `sub` claim → `keycloak.org/id` annotation on the User entity |
+| `preferredUsernameMatchingUserEntityName` | Keycloak `preferred_username` → `metadata.name` |
+| `emailMatchingUserEntityProfileEmail` | OIDC `email` → `spec.profile.email` |
+| `emailLocalPartMatchingUserEntityName` | Email local part → `metadata.name` |
+
+:::tip
+`oidcSubClaimMatchingKeycloakUserId` is the most robust resolver when org sync is active, because Keycloak UUIDs are stable across username changes. The fallback resolvers handle cases where the org sync has not yet run or the user entity has no `keycloak.org/id` annotation.
+:::
+
+## Step 2: Configure org sync
+
+```yaml
+catalog:
+  providers:
+    keycloakOrg:
+      default:
+        baseUrl: ${KEYCLOAK_BASE_URL}
+        loginRealm: ${KEYCLOAK_REALM}
+        realm: ${KEYCLOAK_REALM}
+        clientId: ${KEYCLOAK_CLIENT_ID}
+        clientSecret: ${KEYCLOAK_CLIENT_SECRET}
+        schedule:
+          frequency:
+            minutes: 10
+          initialDelay:
+            seconds: 15
+          timeout:
+            minutes: 10
+```
+
+The `keycloakOrg` provider uses the client's service account to list realm users and groups. The service account must have the `view-users` and `query-groups` roles assigned (in Keycloak, under **Clients → your-client → Service Account Roles**).
+
+## Quick start
+
+```bash
+docker run -p 7007:7007 \
+  -e VEECODE_PROFILE=keycloak \
+  -e KEYCLOAK_BASE_URL=https://keycloak.example.com \
+  -e KEYCLOAK_REALM=my-realm \
+  -e KEYCLOAK_CLIENT_ID=devportal \
+  -e KEYCLOAK_CLIENT_SECRET=<client-secret> \
+  -e AUTH_SESSION_SECRET=<random-secret> \
+  veecode/devportal:latest
+```
+
+### Docker Compose
+
+```yaml
+services:
+  devportal:
+    image: veecode/devportal:latest
+    ports:
+      - "7007:7007"
+    environment:
+      VEECODE_PROFILE: keycloak
+      KEYCLOAK_BASE_URL: https://keycloak.example.com
+      KEYCLOAK_REALM: my-realm
+      KEYCLOAK_CLIENT_ID: devportal
+      KEYCLOAK_CLIENT_SECRET: ${KEYCLOAK_CLIENT_SECRET}
+      AUTH_SESSION_SECRET: ${AUTH_SESSION_SECRET}
+```
+
+## Troubleshooting
+
+- **OIDC discovery fails**: Verify `KEYCLOAK_BASE_URL` is reachable from the DevPortal container. The discovery URL is `${KEYCLOAK_BASE_URL}/realms/${KEYCLOAK_REALM}/.well-known/openid-configuration`.
+- **Sign-in resolvers all fail**: Run org sync first so User entities with `keycloak.org/id` annotations exist in the catalog. Until the first sync completes, only the email-based fallback resolvers will work.
+- **Org sync 403**: The service account is missing `view-users` or `query-groups` roles. Assign them under **Clients → your-client → Service Account Roles** in the Keycloak admin console.
+- **Session errors**: `AUTH_SESSION_SECRET` must be stable across restarts. Changing it invalidates all existing sessions.
+
+## References
+
+- [Backstage OIDC Auth Provider](https://backstage.io/docs/auth/oidc/)
+- [Backstage Keycloak Org Provider](https://backstage.io/docs/integrations/keycloak/org/)
+- [Keycloak Documentation](https://www.keycloak.org/docs/latest/)

--- a/devportal/integrations/Keycloak/keycloak-auth.md
+++ b/devportal/integrations/Keycloak/keycloak-auth.md
@@ -15,7 +15,7 @@ The `keycloak` profile connects VeeCode DevPortal to a Keycloak instance for OID
 
 Set `VEECODE_PROFILE=keycloak` to activate `app-config.keycloak.yaml`.
 
-The entrypoint automatically derives `KEYCLOAK_METADATA_URL` as `${KEYCLOAK_BASE_URL}/realms/${KEYCLOAK_REALM}` if it is not explicitly set.
+The OIDC discovery URL is built from `KEYCLOAK_BASE_URL` + `KEYCLOAK_REALM` (`${KEYCLOAK_BASE_URL}/realms/${KEYCLOAK_REALM}`). The entrypoint also computes and logs this as `KEYCLOAK_METADATA_URL`, but the bundled config derives the URL from the base URL and realm directly — to point at a non-standard discovery endpoint, override `auth.providers` in your own `app-config.local.yaml`.
 
 ## Required environment variables
 
@@ -31,7 +31,7 @@ The entrypoint automatically derives `KEYCLOAK_METADATA_URL` as `${KEYCLOAK_BASE
 
 | Variable | Default | Description |
 |---|---|---|
-| `KEYCLOAK_METADATA_URL` | `${KEYCLOAK_BASE_URL}/realms/${KEYCLOAK_REALM}` | OIDC discovery endpoint (derived automatically if not set) |
+| `KEYCLOAK_METADATA_URL` | `${KEYCLOAK_BASE_URL}/realms/${KEYCLOAK_REALM}` | Computed and logged by the entrypoint for visibility. The bundled config builds the discovery URL from `KEYCLOAK_BASE_URL` + `KEYCLOAK_REALM`, so setting this variable alone does not change it. |
 
 ## Prerequisites
 

--- a/devportal/integrations/LDAP/_category_.json
+++ b/devportal/integrations/LDAP/_category_.json
@@ -1,0 +1,4 @@
+{
+    "label": "LDAP / Active Directory",
+    "position": 6
+  }

--- a/devportal/integrations/LDAP/ldap.md
+++ b/devportal/integrations/LDAP/ldap.md
@@ -33,7 +33,7 @@ LDAP authentication works differently from OAuth/OIDC: the Backstage backend bin
 |---|---|---|---|
 | `LDAP_USERS_FILTER` | `(uid=*)` | — | LDAP filter for user search |
 | `LDAP_GROUPS_FILTER` | `(objectClass=groupOfNames)` | — | LDAP filter for group search |
-| `LDAP_TLS_REJECT_UNAUTHORIZED` | `false` | `true` | Whether to reject self-signed TLS certs |
+| `LDAP_TLS_REJECT_UNAUTHORIZED` | — | `true` | Whether to reject self-signed TLS certs. **`ldap-ad` only** — the `ldap` profile hardcodes `rejectUnauthorized: false` and ignores this variable. |
 | `LDAP_SYNC_FREQUENCY` | `PT1H` (set by entrypoint) | `PT1H` | ISO 8601 duration for org sync frequency (`ldap-ad` only) |
 
 ## Auth configuration

--- a/devportal/integrations/LDAP/ldap.md
+++ b/devportal/integrations/LDAP/ldap.md
@@ -1,0 +1,217 @@
+---
+sidebar_position: 1
+sidebar_label: LDAP / Active Directory
+title: LDAP & Active Directory Auth
+---
+
+VeeCode DevPortal ships two LDAP profiles:
+
+| Profile | `VEECODE_PROFILE` | Use case |
+|---|---|---|
+| `ldap` | `ldap` | Generic OpenLDAP-compatible directories (uses `uid` as username attribute) |
+| `ldap-ad` | `ldap-ad` | Active Directory / Samba AD (uses `sAMAccountName`, AD object classes) |
+
+Both profiles configure the `ldap` auth provider for direct user authentication and the `ldapOrg` catalog provider for org sync.
+
+:::note
+LDAP authentication works differently from OAuth/OIDC: the Backstage backend binds directly to the LDAP server using an admin credential, then validates user credentials by attempting a bind as the authenticating user. There is no redirect flow.
+:::
+
+## Required environment variables (both profiles)
+
+| Variable | Description |
+|---|---|
+| `LDAP_URL` | LDAP server URL (e.g., `ldap://ldap.example.com:389` or `ldaps://ldap.example.com:636`) |
+| `LDAP_DN` | Bind DN for the admin/service account (e.g., `cn=admin,dc=example,dc=com`) |
+| `LDAP_SECRET` | Password for the admin bind DN |
+| `LDAP_USERS_BASE_DN` | Base DN for user search (e.g., `ou=users,dc=example,dc=com`) |
+| `LDAP_GROUPS_BASE_DN` | Base DN for group search (e.g., `ou=groups,dc=example,dc=com`) |
+
+## Optional environment variables
+
+| Variable | Default (ldap) | Default (ldap-ad) | Description |
+|---|---|---|---|
+| `LDAP_USERS_FILTER` | `(uid=*)` | — | LDAP filter for user search |
+| `LDAP_GROUPS_FILTER` | `(objectClass=groupOfNames)` | — | LDAP filter for group search |
+| `LDAP_TLS_REJECT_UNAUTHORIZED` | `false` | `true` | Whether to reject self-signed TLS certs |
+| `LDAP_SYNC_FREQUENCY` | `PT1H` (set by entrypoint) | `PT1H` | ISO 8601 duration for org sync frequency (`ldap-ad` only) |
+
+## Auth configuration
+
+### `ldap` profile
+
+```yaml
+signInPage: ldap
+
+auth:
+  environment: development
+  providers:
+    ldap:
+      development:
+        cookies:
+          secure: false
+          field: "backstage-token"
+        ldapAuthenticationOptions:
+          userSearchBase: "${LDAP_USERS_BASE_DN}"
+          usernameAttribute: "uid"
+          adminDn: "${LDAP_DN}"
+          adminPassword: "${LDAP_SECRET}"
+          ldapOpts:
+            url: "${LDAP_URL}"
+            tlsOptions:
+              rejectUnauthorized: false
+```
+
+### `ldap-ad` profile (Active Directory)
+
+The `ldap-ad` profile uses `sAMAccountName` as the username attribute, which is the standard login name in Active Directory. TLS verification defaults to `true`.
+
+```yaml
+signInPage: ldap
+
+auth:
+  environment: development
+  providers:
+    ldap:
+      development:
+        cookies:
+          secure: false
+          field: "backstage-token"
+        ldapAuthenticationOptions:
+          userSearchBase: "${LDAP_USERS_BASE_DN}"
+          usernameAttribute: sAMAccountName
+          adminDn: "${LDAP_DN}"
+          adminPassword: "${LDAP_SECRET}"
+          ldapOpts:
+            url: "${LDAP_URL}"
+            tlsOptions:
+              rejectUnauthorized: ${LDAP_TLS_REJECT_UNAUTHORIZED}
+```
+
+## Org sync configuration
+
+### `ldap` profile
+
+```yaml
+catalog:
+  providers:
+    ldapOrg:
+      default:
+        target: "${LDAP_URL}"
+        bind:
+          dn: "${LDAP_DN}"
+          secret: "${LDAP_SECRET}"
+        users:
+          - dn: "${LDAP_USERS_BASE_DN}"
+            options:
+              filter: "${LDAP_USERS_FILTER:(uid=*)}"
+            map:
+              description: l
+        groups:
+          - dn: "${LDAP_GROUPS_BASE_DN}"
+            options:
+              filter: "${LDAP_GROUPS_FILTER:(objectClass=groupOfNames)}"
+            map:
+              description: l
+        schedule:
+          frequency: PT1H
+          timeout: PT15M
+```
+
+### `ldap-ad` profile (Active Directory)
+
+The AD variant maps AD-specific attributes (`sAMAccountName`, `memberOf`, `member`, `displayName`, `mail`) to Backstage entity fields.
+
+```yaml
+catalog:
+  providers:
+    ldapOrg:
+      default:
+        target: "${LDAP_URL}"
+        bind:
+          dn: "${LDAP_DN}"
+          secret: "${LDAP_SECRET}"
+        users:
+          - dn: "${LDAP_USERS_BASE_DN}"
+            options:
+              filter: "${LDAP_USERS_FILTER}"
+              scope: sub
+            map:
+              rdn: cn
+              name: sAMAccountName
+              description: description
+              displayName: displayName
+              email: mail
+              memberOf: memberOf
+        groups:
+          - dn: "${LDAP_GROUPS_BASE_DN}"
+            options:
+              filter: "${LDAP_GROUPS_FILTER}"
+              scope: sub
+            map:
+              rdn: cn
+              name: cn
+              description: description
+              displayName: cn
+              memberOf: memberOf
+              members: member
+        schedule:
+          frequency: ${LDAP_SYNC_FREQUENCY}
+          timeout: PT15M
+```
+
+## Quick start
+
+### OpenLDAP (`ldap` profile)
+
+```bash
+docker run -p 7007:7007 \
+  -e VEECODE_PROFILE=ldap \
+  -e LDAP_URL=ldap://ldap.example.com:389 \
+  -e LDAP_DN="cn=admin,dc=example,dc=com" \
+  -e LDAP_SECRET=<admin-password> \
+  -e LDAP_USERS_BASE_DN="ou=users,dc=example,dc=com" \
+  -e LDAP_GROUPS_BASE_DN="ou=groups,dc=example,dc=com" \
+  veecode/devportal:latest
+```
+
+### Active Directory (`ldap-ad` profile)
+
+```bash
+docker run -p 7007:7007 \
+  -e VEECODE_PROFILE=ldap-ad \
+  -e LDAP_URL=ldaps://ad.example.com:636 \
+  -e LDAP_DN="CN=svc-devportal,OU=ServiceAccounts,DC=example,DC=com" \
+  -e LDAP_SECRET=<service-account-password> \
+  -e LDAP_USERS_BASE_DN="OU=Users,DC=example,DC=com" \
+  -e LDAP_GROUPS_BASE_DN="OU=Groups,DC=example,DC=com" \
+  -e LDAP_USERS_FILTER="(objectClass=user)" \
+  -e LDAP_GROUPS_FILTER="(objectClass=group)" \
+  -e LDAP_TLS_REJECT_UNAUTHORIZED=true \
+  veecode/devportal:latest
+```
+
+## Choosing between `ldap` and `ldap-ad`
+
+| Concern | `ldap` | `ldap-ad` |
+|---|---|---|
+| Username attribute | `uid` | `sAMAccountName` |
+| User object class filter | `uid=*` | Set via `LDAP_USERS_FILTER` |
+| Group object class filter | `objectClass=groupOfNames` | Set via `LDAP_GROUPS_FILTER` |
+| Group membership attribute | standard LDAP `member` | `member` (DN-based, AD style) |
+| TLS rejection default | `false` | `true` |
+| Sync frequency | `PT1H` | Configurable via `LDAP_SYNC_FREQUENCY` |
+
+For Windows Active Directory or Samba AD, always use `ldap-ad`. For FreeIPA, OpenLDAP, or 389 Directory Server, use `ldap` and adjust filters as needed.
+
+## Troubleshooting
+
+- **Bind error at startup**: Verify `LDAP_DN` and `LDAP_SECRET` can bind to the server. Test with `ldapsearch -H $LDAP_URL -D "$LDAP_DN" -w "$LDAP_SECRET" -b "$LDAP_USERS_BASE_DN" "(uid=*)"`.
+- **TLS certificate error**: For self-signed certs, set `LDAP_TLS_REJECT_UNAUTHORIZED=false` (or add the CA cert to the container's trust store).
+- **No users ingested**: Check that `LDAP_USERS_FILTER` matches at least one entry under `LDAP_USERS_BASE_DN`. For AD, a common filter is `(objectClass=user)`.
+- **Sign-in fails but user exists in catalog**: The username attribute in the auth options must match what the user types at the login prompt. For AD, users log in with their `sAMAccountName`; for OpenLDAP, typically their `uid`.
+
+## References
+
+- [Backstage LDAP Org Provider](https://backstage.io/docs/integrations/ldap/org/)
+- [Backstage LDAP Auth Provider](https://backstage.io/docs/auth/ldap/provider/)

--- a/devportal/integrations/integrations.md
+++ b/devportal/integrations/integrations.md
@@ -4,7 +4,21 @@ sidebar_label: Auth & Integrations
 title: Auth & Integrations
 ---
 
-An usually confusing topic in Backstage world are its backend integrations and authentication mechanisms. This section explain a bit of this and prepares you to understand common senarios and to read deeper documentation.
+An usually confusing topic in Backstage world are its backend integrations and authentication mechanisms. This section explains a bit of this and prepares you to understand common scenarios and to read deeper documentation.
+
+## Supported providers
+
+VeeCode DevPortal ships pre-configured profiles for the following identity and SCM providers. Each provider page covers the required env vars, auth config, sign-in resolvers, org-sync config, and a minimal deployment example.
+
+| Provider | Profile | Auth type | Org sync |
+|---|---|---|---|
+| [GitHub](./GitHub/github.md) | `github` | OAuth 2.0 (OAuth App or GitHub App) | GitHub Org / Teams |
+| [GitHub PAT](./GitHub/github-integrations.md) | `github-pat` | Guest (no auth) | GitHub Org catalog sync only |
+| [GitLab](./GitLab/gitlab.md) | `gitlab` | OAuth 2.0 | GitLab Groups |
+| [Azure / Microsoft](./Azure/azure.md) | `azure` | Microsoft OIDC | Microsoft Graph (Azure AD) |
+| [Keycloak](./Keycloak/keycloak-auth.md) | `keycloak` | OIDC | Keycloak Realm |
+| [LDAP / Active Directory](./LDAP/ldap.md) | `ldap` / `ldap-ad` | LDAP bind | LDAP org sync |
+| [MCP (AI Tooling)](./mcp.md) | any | OAuth 2.1 + DCR | n/a |
 
 ## Why should I read this?
 

--- a/devportal/integrations/mcp.md
+++ b/devportal/integrations/mcp.md
@@ -9,7 +9,7 @@ DevPortal exposes an MCP (Model Context Protocol) server that lets external AI t
 Two independent capabilities:
 
 1. **MCP server for external clients** — OAuth per-user authentication, no LLM API key required
-2. **AI Chat in-portal** — optional; requires an LLM API key (OpenAI or Anthropic)
+2. **AI Chat in-portal** — optional; requires an LLM API key (OpenAI, Anthropic, Gemini, or Ollama)
 
 ## For platform teams
 
@@ -20,7 +20,7 @@ Go to **Configure → Integrations** and open the **MCP + AI Chat** card.
 1. Click **Connect**
 2. The dialog opens with the default action **"Enable MCP server"**
 3. (Optional) Toggle **"Also add AI Chat in portal"**
-4. If AI Chat is on, select provider (OpenAI or Anthropic) and provide the API key
+4. If AI Chat is on, select provider (OpenAI, Anthropic, Gemini, or Ollama) and provide the API key
 5. Confirm — the button label reflects what will be provisioned:
    - **Enable MCP server** — MCP server only
    - **Enable MCP + AI Chat** — MCP server + in-portal chat
@@ -50,8 +50,9 @@ Add the following to your `dynamic-plugins.yaml`:
 
 ```yaml
 plugins:
-  - disabled: false
-    package: oci://quay.io/veecode/backstage:bs_1.49.4!backstage-plugin-mcp-actions-backend
+  # MCP Actions Backend — exposes Backstage actions as MCP tools
+  - package: oci://quay.io/veecode/backstage:bs_1.49.4!backstage-plugin-mcp-actions-backend
+    disabled: false
     pluginConfig:
       backend:
         actions:
@@ -62,6 +63,14 @@ plugins:
             - scaffolder-mcp-extras
             - catalog
             - scaffolder
+
+  # MCP Tool Plugins — must be enabled individually so the plugin packages are loaded
+  - package: oci://quay.io/veecode/mcp-integrations:bs_1.49.4!red-hat-developer-hub-backstage-plugin-software-catalog-mcp-extras
+    disabled: false
+  - package: oci://quay.io/veecode/mcp-integrations:bs_1.49.4!red-hat-developer-hub-backstage-plugin-techdocs-mcp-extras
+    disabled: false
+  - package: oci://quay.io/veecode/mcp-integrations:bs_1.49.4!red-hat-developer-hub-backstage-plugin-scaffolder-mcp-extras
+    disabled: false
 ```
 
 :::warning
@@ -138,6 +147,22 @@ url = "https://<your-instance>/api/mcp-actions/v1"
 ```
 
 On first use, the client opens a browser window for the OAuth authorization flow. No manual token management is needed.
+
+### Cursor
+
+Add to your Cursor MCP configuration (`.cursor/mcp.json` in the project root, or the global Cursor settings under **Settings → MCP**):
+
+```json
+{
+  "mcpServers": {
+    "devportal": {
+      "url": "https://<your-instance>/api/mcp-actions/v1"
+    }
+  }
+}
+```
+
+On first use, Cursor triggers the OAuth authorization flow and stores the resulting token. The server will appear in the Cursor MCP panel under **Tools**.
 
 ## Advanced configuration
 

--- a/devportal/intro.md
+++ b/devportal/intro.md
@@ -49,7 +49,7 @@ export const Card = ({children, title, link}) => (
 
 <!-- <Card title="📄️ Self-Service Demo" link="self-service-demo/prerequisites">Explore the platform's features through a simple interactive demo.</Card> -->
 
-<Card title="💻 Installation Guide" link="/devportal/installation-guide/simple-setup">Learn how to install the Developer Portal on your own infrastructure.</Card>
+<Card title="💻 Installation Guide" link="/devportal/installation-guide/simple-setup/simple-setup">Learn how to install the Developer Portal on your own infrastructure.</Card>
 
 <Card title="💡 Concepts" link="/devportal/concepts/catalog">Understand the core concepts and terminology related to the Developer Portal.</Card>
 

--- a/devportal/intro.md
+++ b/devportal/intro.md
@@ -49,7 +49,7 @@ export const Card = ({children, title, link}) => (
 
 <!-- <Card title="📄️ Self-Service Demo" link="self-service-demo/prerequisites">Explore the platform's features through a simple interactive demo.</Card> -->
 
-<Card title="💻 Installation Guide" link="/devportal/installation-guide/simple-setup/simple-setup">Learn how to install the Developer Portal on your own infrastructure.</Card>
+<Card title="💻 Installation Guide" link="/devportal/installation-guide/simple-setup">Learn how to install the Developer Portal on your own infrastructure.</Card>
 
 <Card title="💡 Concepts" link="/devportal/concepts/catalog">Understand the core concepts and terminology related to the Developer Portal.</Card>
 

--- a/devportal/observability/Introduction.md
+++ b/devportal/observability/Introduction.md
@@ -4,49 +4,43 @@ sidebar_label: Introduction
 title: Introduction
 ---
 
-Welcome to the Observability Module in our Developer Portal! In this comprehensive guide, we will explore the powerful capabilities offered by the observability stack.
+DevPortal's observability integration allows you to surface metrics, dashboards, and alert status from your existing observability stack **directly on catalog entity pages**. DevPortal does not provision or manage Prometheus, Jaeger, Loki, or Grafana — these tools must be deployed and operated separately. DevPortal connects to them through the optional Grafana dynamic plugin and catalog entity annotations.
 
-## **The Observability Stack**
+## **How the Integration Works**
 
-### Prometheus for Metric Collection
+The integration is display-only:
 
-Prometheus is a leading open-source monitoring and alerting solution designed to scrape, store, and query time-series data. With its flexible data model and powerful query language, Prometheus enables the collection of various system and application metrics. By having a deep insight into your system's performance and resource utilization, developers and operations teams can identify performance bottlenecks and troubleshoot issues effectively.
+1. You deploy Prometheus, Grafana, Loki, and/or Jaeger in your infrastructure (outside of DevPortal).
+2. You enable the **Grafana plugin** in DevPortal's `dynamic-plugins.yaml`.
+3. You annotate your catalog entities (`catalog-info.yaml`) with the appropriate annotation keys to tell DevPortal where to find dashboards and alerts.
+4. DevPortal renders Grafana dashboards and alert summaries as tabs and cards on the entity page.
 
-### Jaeger for Tracing
+Jaeger traces and Loki logs are surfaced as external links (URL annotations) that open the relevant tool in a browser — they are not embedded views.
 
-Jaeger is a distributed tracing system, which helps you monitor and troubleshoot complex microservices architectures. It allows you to visualize and analyze the flow of requests through your application, pinpointing latency bottlenecks and identifying areas for performance optimization. Jaeger's interactive trace graphs provide a comprehensive view of your application's behavior and dependencies, facilitating root cause analysis and improving overall system reliability.
+---
 
-### Loki for Log Management
+## **The Observability Stack (External)**
 
-Loki is a horizontally-scalable log aggregation system, designed specifically for cloud-native environments. It efficiently collects, indexes, and stores logs, enabling easy searching and filtering capabilities. By centralizing logs in Loki, you can efficiently monitor and troubleshoot applications, quickly respond to incidents, and gain valuable insights into your system's behavior.
+To use DevPortal's observability integration, you need these tools running externally:
 
-### Grafana for Unified Visualization
+### Prometheus
+Prometheus collects and stores time-series metrics from your services. Grafana queries Prometheus to render dashboards and evaluate alert rules.
 
-Grafana acts as the unified user interface for the entire observability stack. It allows you to create rich, interactive dashboards that combine metrics, traces, and logs from Prometheus, Jaeger, and Loki. Grafana's powerful visualization capabilities enable you to monitor your system's health, track performance trends over time, and set up alerting to be notified of any abnormal conditions promptly.
+### Grafana
+Grafana is the unified visualization layer. The Grafana plugin in DevPortal displays Grafana dashboards and alert status panels embedded on component pages.
 
-## **Benefits of Implementing Observability in DevPortal**
+### Loki (optional)
+Loki aggregates and indexes logs. Log links can be added as URL annotations on catalog entities, opening the Loki/Grafana Explore view in the browser.
 
-### **Simplified Implementation**
+### Jaeger (optional)
+Jaeger handles distributed tracing. Trace links can be added as URL annotations on catalog entities, opening Jaeger's trace view in the browser.
 
-Implementing and configuring observability stacks like Prometheus, Jaeger, Loki, and Grafana can be a challenging task, requiring specialized knowledge and expertise. By providing an integrated Observability Module in our Developer Portal, we streamline the setup process, abstracting the complexities of these tools' implementation. This simplification allows developers to focus on their core tasks, knowing that the observability infrastructure is efficiently managed.
+---
 
-### **Enhanced System Administration**
+## **What DevPortal Provides**
 
-Observability is crucial for modern application development and operations. By centralizing the entire observability stack within the DevPortal, administrators can efficiently manage and monitor multiple components and services. This centralization brings cohesion to the observability process, making it easier to oversee and maintain a holistic view of the system's health and performance.
+- A Grafana dynamic plugin (not bundled — must be enabled explicitly) that reads catalog annotations and renders dashboards/alerts on entity pages.
+- Catalog annotation conventions for pointing entities to the correct Grafana dashboards, alert labels, and external trace/log URLs.
+- A unified experience: developers can access observability data from the same entity page where they view source code, CI/CD status, and docs.
 
-### **Empowering Developers**
-
-Our Observability Module empowers developers to gain insights into the behavior of their applications without being overwhelmed by the intricacies of configuring different observability tools. With an intuitive and unified user interface, developers can explore metrics, traces, and logs conveniently, making data-driven decisions to optimize performance and improve the end-user experience.
-
-### **Accelerated Troubleshooting**
-
-When issues arise, quick and efficient troubleshooting is essential to reduce downtime and maintain service reliability. The Observability Module equips developers and operations teams with the tools they need to rapidly identify and resolve incidents. The combination of metrics, traces, and logs in a single interface streamlines the incident response process, leading to faster resolutions and minimizing the impact on users.
-
-### **Foster a DevOps Culture**
-
-Observability is a fundamental aspect of the DevOps culture, emphasizing collaboration and shared ownership of the software development lifecycle. By providing developers and operations teams with easy access to observability data, our Observability Module encourages transparency and cooperation, driving the adoption of DevOps best practices across the organization.
-
-
-With the Observability Module in our Developer Portal, we bring powerful and complex observability tools - Prometheus, Jaeger, Loki, and Grafana - within easy reach. By simplifying the implementation and centralizing observability features, we empower developers and operations teams to efficiently monitor, troubleshoot, and optimize their applications. Embrace the power of observability to enhance system administration, accelerate troubleshooting, and cultivate a DevOps culture within your organization.
-
-To dive deeper into the execution of these concepts and witness the practical functionality of observability through our platform, we invite you to proceed to the next topic: **"Observability Dashboard: Exploring Application Insights"**. In this section, we will take you through a guided tour of the Observability Dashboard, demonstrating how it seamlessly integrates Prometheus, Jaeger, Loki, and Grafana to provide real-time insights and streamline your monitoring and debugging workflows.
+For plugin setup and required annotations, see [Observability Dashboard](./dashboard.md).

--- a/devportal/observability/dashboard.md
+++ b/devportal/observability/dashboard.md
@@ -41,7 +41,6 @@ To enable observability panels on an entity page, add the following annotations 
 metadata:
   annotations:
     grafana/dashboard-selector: "title @> 'My Service'"
-    grafana/unified-thematic-label: "service=my-service"
 ```
 
 ### Grafana Alert Status Panel

--- a/devportal/observability/dashboard.md
+++ b/devportal/observability/dashboard.md
@@ -1,73 +1,93 @@
 ---
 sidebar_position: 7
 sidebar_label: Template Dashboards
-title: Template Dashboards
+title: Observability Dashboard
 ---
 
-import logImg from "/img/assets/log.png"
-import metricsImg from "/img/assets/metrics.png"
-import traceImg from "/img/assets/trace.png"
+This page explains how to configure the Grafana plugin in DevPortal and what catalog annotations are required to surface observability data on entity pages.
 
-Welcome to the Observability Dashboard in our Developer Portal! In this section, we will take you through a guided tour of the Observability Dashboard, where you can explore real-time insights and monitoring data for your applications. 
+DevPortal does **not** embed Prometheus, Jaeger, or Loki directly. Instead, it integrates with externally-deployed instances of these tools through the Grafana plugin and catalog entity annotations.
 
-## **Accessing the Observability Dashboard**
+---
 
-1. **Navigate to the Developer Portal:** To access the Observability Dashboard, start by visiting our Developer Portal.
-2. **Catalog View:** Once you are on the Developer Portal homepage, choose the "Catalog" option from the menu.
-3. **Filter by Component:** In the catalog view, you can filter components to find the one you are interested in monitoring. Locate and select the component that has the Grafana plugin configured for observability.
-4. **Observability Links:** Upon selecting the component, you will find dedicated links that provide you with easy access to various observability views:
-    - **Trace View:** where you can explore distributed traces and trace details for your application.
-    - **Metric View:** where you can visualize and analyze metrics collected by Prometheus. Observe performance trends and detect anomalies in real-time.
-    - **Log View:** where you can search and analyze logs from your application. This is invaluable for troubleshooting and understanding application behavior.
+## **Setting Up the Grafana Plugin**
 
-## **Grafana Dashboard: Metrics View**
+The Grafana plugin is not bundled in the default image. Add it to your `dynamic-plugins.yaml` as an external plugin. Refer to the [Grafana plugin guide](/devportal/plugins/grafana) for the full plugin package reference and configuration.
 
-In the Metrics View of the Observability Dashboard, you will find a collection of interactive and customizable dashboards powered by Prometheus and Grafana. These dashboards offer a rich set of visualizations and widgets that enable you to monitor various aspects of your application's performance, resource utilization, and health.
+At minimum, configure the Grafana proxy in your app-config:
 
-<center>
-<img src={metricsImg}/>
-</center>
+```yaml
+proxy:
+  endpoints:
+    /grafana/api:
+      target: https://your-grafana-instance.example.com
+      headers:
+        Authorization: Bearer ${GRAFANA_TOKEN}
+      changeOrigin: true
 
+grafana:
+  domain: https://your-grafana-instance.example.com
+```
 
-### **Key Features:**
+---
 
-- **Pre-configured Dashboards:** We provide a set of pre-configured dashboards that cover common performance metrics for your application, including CPU usage, memory consumption, request latency, and more.
-- **Customizable Widgets:** You have the flexibility to customize existing widgets or create new ones tailored to your specific monitoring needs. This allows you to visualize the metrics that are most relevant to your application.
-- **Alerting and Notifications:** Set up alerting rules to be notified when certain metrics exceed predefined thresholds. Receive notifications via email, Slack, or other channels to take timely actions on critical issues.
-- **Time-Based Analysis:** The Grafana dashboard enables you to analyze historical data by adjusting the time range. This feature allows you to perform retrospective analysis and identify trends over time.
+## **Catalog Annotations**
 
-## **Jaeger Tracing: Trace View**
+To enable observability panels on an entity page, add the following annotations to the entity's `catalog-info.yaml`:
 
-In the Trace View of the Observability Dashboard, Jaeger provides a powerful interface to explore distributed traces across your application. Tracing enables you to visualize the entire flow of a request as it travels through various microservices and components.
+### Grafana Dashboard Panel
 
-<center>
-<img src={traceImg}/>
-</center>
+```yaml
+metadata:
+  annotations:
+    grafana/dashboard-selector: "title @> 'My Service'"
+    grafana/unified-thematic-label: "service=my-service"
+```
 
-### **Key Features:**
+### Grafana Alert Status Panel
 
-- **Trace Visualization:** Jaeger displays traces as a directed acyclic graph, making it easy to visualize the sequence of calls and dependencies within your distributed system.
-- **Service Dependencies:** Identify the relationships between different services and understand how they interact to process a request.
-- **Latency Analysis:** Trace View allows you to inspect the latency of individual spans (operations) within a trace. Identify bottlenecks and performance issues that impact request processing time.
-- **Error Analysis:** Spot errors and exceptions that occur during request processing and quickly drill down to the root cause for troubleshooting.
+```yaml
+metadata:
+  annotations:
+    grafana/alert-label-selector: "service=my-service"
+```
 
-## **Loki Log Viewer: Log View**
+### External Trace Links (Jaeger)
 
-The Log View of the Observability Dashboard powered by Loki presents a powerful log aggregation and searching capability. Easily navigate through logs generated by your application to diagnose issues, detect anomalies, and investigate system behavior.
+Jaeger traces are surfaced as external links — clicking opens Jaeger in a new browser tab:
 
-<center>
-<img src={logImg}/>
-</center>
+```yaml
+metadata:
+  annotations:
+    jaeger/service-name: my-service
+```
 
-### **Key Features:**
+*(Exact annotation keys depend on which Jaeger/tracing annotation plugin you have enabled.)*
 
-- **Log Aggregation:** Loki efficiently collects and indexes logs from various sources, allowing you to access logs for your application in a centralized and easily searchable manner.
-- **Dynamic Queries:** Perform dynamic searches using log labels and keywords to narrow down logs relevant to specific components or events.
-- **Log Visualization:** Visualize log data with histograms, bar charts, and other Grafana log-specific visualizations for quick insights.
-- **Log Stream:** Observe logs in real-time with a live log stream view, making it easy to monitor events as they occur.
+### External Log Links (Loki)
 
-The Observability Dashboard in our Developer Portal provides you with a powerful set of tools to monitor, troubleshoot, and optimize your applications effectively. By integrating Prometheus, Jaeger, Loki, and Grafana, we offer you a unified and seamless experience to explore metrics, traces, and logs in real-time. Embrace the power of observability to gain a deep understanding of your application's performance, enhance reliability, and foster a proactive DevOps culture.
+Loki logs are surfaced as external links to the Grafana Explore view:
 
-Reach out to our expert team to schedule a personalized demonstration and discover how our Observability Module can be tailored to meet your organization's unique needs. Our dedicated team will guide you through the platform's capabilities, provide best practices, and help you maximize the benefits of observability.
+```yaml
+metadata:
+  annotations:
+    grafana/tag-filter: "service=my-service"
+```
 
-**To book a demonstration** or inquire about any aspect of our Observability Module, please don't hesitate to **contact us [here](https://platform.vee.codes/contact-us/)**. We look forward to showcasing the power of observability and how it can transform your application monitoring and management processes.
+---
+
+## **Accessing the Observability Data**
+
+1. **Navigate to the Catalog:** Select the component you want to observe.
+2. **Open the entity page:** Look for the Grafana plugin tab or cards in the Overview section.
+3. **Metrics view:** Grafana dashboards matching the `dashboard-selector` annotation are displayed inline.
+4. **Alert status:** Alert panels matching the `alert-label-selector` annotation show current alert state.
+5. **Trace/Log links:** If trace or log annotations are configured, links appear on the entity page that open the respective tools in your browser.
+
+---
+
+:::info External tools required
+The Grafana, Prometheus, Loki, and Jaeger instances must be separately deployed and accessible to both DevPortal's backend (for API calls) and end users' browsers (for direct links). DevPortal does not provision or manage these services.
+:::
+
+For more on the plugin, see the [Grafana Plugin guide](/devportal/plugins/grafana).

--- a/devportal/plugins/GitHubWorkflows.md
+++ b/devportal/plugins/GitHubWorkflows.md
@@ -1,476 +1,172 @@
-# Github Workflows
+---
+sidebar_position: 6
+sidebar_label: GitHub Workflows
+title: GitHub Workflows Plugin
+---
 
+# GitHub Workflows Plugin
 
-The GithubWorkflows plugin provides an alternative for manually triggering GitHub workflows from within your Backstage component.
+The GitHub Workflows plugin provides an alternative for manually triggering GitHub workflows from within your DevPortal component. It offers two distinct approaches:
 
-The plugin offers two distinct approaches to integrate with your component:
+- **Workflows List** — lists all workflows in the repository, with branch selection and manual trigger support.
+- **Workflow Cards** — an overview card showing only workflows pinned via annotation.
 
-- On-demand workflows, which are configured via annotations in your project's `catalog-info.yaml`.
-- A complete listing of the workflows available in your project.
+### Community
 
-
-
-### Our community
-
-> 💬  **Join Us**
+> Join our community to resolve questions about our Plugins. We look forward to welcoming you!
 >
-> Join our community to resolve questions about our **Plugins**. We look forward to welcoming you! 
->
->    [Go to Community  🚀](https://github.com/orgs/veecode-platform/discussions)
+> [Go to Community](https://github.com/orgs/veecode-platform/discussions)
 
+---
 
+## Plugin packages
 
-### Getting Started:
+| Package | Role |
+|---|---|
+| `veecode-platform-backstage-plugin-github-workflows-dynamic` | Frontend — entity card and tab |
+| `veecode-platform-backstage-plugin-github-workflows-backend-dynamic` | Backend — GitHub API proxy |
 
+Both are preloaded in the DevPortal image and **disabled by default**. No image rebuild is needed.
 
+---
 
-Before installing the plugin, there are some prerequisites to ensure its functionality:
+## Enabling the plugin
 
-- Have a locally installed Backstage project, :heavy_check_mark: [How to create a Backstage app :page_with_curl:](https://backstage.io/docs/getting-started/create-an-app) .
-- Set up the catalog and integrate with GitHub, :heavy_check_mark: [How to configure the integration :page_with_curl:](https://backstage.io/docs/integrations/) .
-- Configure GitHub authentication, :heavy_check_mark: [How to configure authentication :page_with_curl:](https://backstage.io/docs/auth/) .
-- Configure the default GitHub Actions plugin, :heavy_check_mark: [Documentation of the Github actions plugin :page_with_curl:](https://github.com/backstage/backstage/tree/master/plugins/github-actions) .
-
-
-### Installation
-
-If you are using yarn 3.x:
-
-```bash
-yarn workspace app add @veecode-platform/backstage-plugin-github-workflows
-```
-
-If you are using other versions:
-
-```bash
-yarn add --cwd packages/app @veecode-platform/backstage-plugin-github-workflows
-```
-
-
-
-### Configuration
-
-We'll divide the configuration into three steps:
-
-1- Proxy Configuration.
-
-1.1 - Using github auth provider:
-
-> :information_source: Make sure you have an github auth provider in your devportal. See how [Add Github Auth Provider 📃](https://backstage.io/docs/auth/github/provider)
+Add the following to your `dynamic-plugins.yaml` (or the equivalent YAML section in your deployment):
 
 ```yaml
-auth:
-  environment: development
-  providers: 
-    github:
-      development:
-        clientId: ${AUTH_GITHUB_CLIENT_ID}
-        clientSecret: ${AUTH_GITHUB_CLIENT_SECRET}
+plugins:
+  - package: ./dynamic-plugins/dist/veecode-platform-backstage-plugin-github-workflows-backend-dynamic
+    disabled: false
+
+  - package: ./dynamic-plugins/dist/veecode-platform-backstage-plugin-github-workflows-dynamic
+    disabled: false
+    pluginConfig:
+      dynamicPlugins:
+        frontend:
+          veecode-platform.backstage-plugin-github-workflows:
+            mountPoints:
+              - mountPoint: entity.page.overview/cards
+                importName: EntityGithubWorkflowsCard
+                config:
+                  layout:
+                    gridRowStart:
+                      lg: "4"
+                    gridColumnStart:
+                      lg: "1"
+                    gridColumnEnd:
+                      lg: "span 6"
+                  if:
+                    anyOf:
+                      - hasAnnotation: "github.com/workflows"
+                      - hasAnnotation: "vee.codes/has-github-workflows"
 ```
+
+Restart DevPortal after saving. Via the Marketplace UI you can click **Enable** instead of editing YAML manually.
+
+---
+
+## GitHub integration
+
+The plugin reads workflow data from the GitHub API using the GitHub integration configured in `app-config.yaml`. Ensure `integrations.github` is configured with a token or GitHub App credentials.
 
 ```yaml
-proxy:
-  '/github/api':
-    target: https://api.github.com/repos
-    allowedHeaders: ['Authorization', 'X-GitHub-Api-Version']
-    headers: 
-      Accept: application/vnd.github+json
-      X-GitHub-Api-Version: "2022-11-28"
+integrations:
+  github:
+    - host: github.com
+      token: ${GITHUB_TOKEN}
 ```
 
+No proxy configuration is needed for DevPortal — the backend plugin handles GitHub API calls server-side.
 
+---
 
-2- To trigger workflows directly from our component, it's important to add the ` workflow_dispatch:` step in our GitHub workflow, like this:
+## Prerequisites in GitHub
 
-```diff
-# Workflow Example
+To allow triggering workflows from the plugin, add `workflow_dispatch:` to each workflow you want to trigger:
 
-name: Deploy Next.js site to Pages
-
+```yaml
+name: My Workflow
 on:
   push:
-    branches: ["master"]
-+ workflow_dispatch:
-
- ....
+    branches: ["main"]
+  workflow_dispatch:    # required for manual trigger support
 ```
 
+The key must be present even when no inputs are defined.
 
-Even if no parameters are passed to this key, it must be present in the file to enable event triggering through the Backstage component.
+---
 
+## Annotations
 
->
->
->#####  Parameters
->
->:information_source: It's possible to set parameters in the workflow as well, and the plugin understands them. Actions will only be triggered if the required parameters are sent.
->
->
+### `github.com/project-slug` (required)
 
-
-
-
-
-3- We need a primary annotation, commonly used by all Backstage components,`github.com/project-slug`, where the project name is set.
-
-As a main prerequisite, this annotation must be declared in the `catalog-info.yaml`of the component that will receive this functionality.
-
-
-```diff
-apiVersion: backstage.io/v1alpha1
-kind: Component
-metadata:
-  name: "Example Component"
-  description: "An example Backstage Components"
-  links:
-    - title: Website
-      url: http://backstage.io
-    - title: Documentation
-      url: https://backstage.io/docs
-    - title: Storybook
-      url: https://backstage.io/storybook
-    - title: Discord Chat
-      url: https://discord.com/invite/EBHEGzX
-  annotations:
-+    github.com/project-slug: example/ExampleComponent
-    backstage.io/techdocs-ref: dir:.
-   
-spec:
-  type: website
-  lifecycle: experimental
-  owner: default
-```
-
-
-
-* * *
-
- 
-
-### Workflows List
-
-
-
-
-![image](https://github.com/veecode-platform/platform-backstage-plugins/assets/84424883/6c82c7c7-b7e3-4bde-853f-c161e71dbb9e)
-
-
-
-
-
-The component essentially lists all the workflows available in the repository.
-In its header, we highlight the select that filters all available branches in the project and the refresh button to update the workflow states.
-
-The table is divided by workflow name, status, action, and link to the repository.
-
-In some cases, to trigger an action, it may require parameters, as configured in your workflow. Instead of an action button, a modal is displayed to set the requested parameters:
-
-
-
-![image2](https://github.com/veecode-platform/platform-backstage-plugins/assets/84424883/06390934-c04e-4059-bf01-551a467a294a)
-
-
-
-When an event is triggered in the workflow, the status is updated, and the conclusion is returned after refreshing the table.
-
-
-
-![image3](https://github.com/veecode-platform/platform-backstage-plugins/assets/84424883/9b92c472-45de-4e64-9618-b96cc8a574c3)
-
-
-
-We encourage users to create a new tab in their catalog named "Workflows" and keep the "CI-CD" tab with the default Backstage component. In the following sections, we'll explain the integration between the two plugins.
-
-
-
-**Example of adding the new tab to a serviceEntityPage**
-`packages/app/src/components/catalog/EntityPage.tsx`
-
-
-
-```diff
-+ import { GithubWorkflowsList, isGithubAvailable } from '@veecode-platform/backstage-plugin-github-workflows'
-...
-
-+ const WorkflowsContent = (
-+  <EntitySwitch>
-+    <EntitySwitch.Case if={isGithubActionsAvailable}>
-+      <GithubWorkflowsList/>
-+    </EntitySwitch.Case>
-+
-+    <EntitySwitch.Case>
-+      <EmptyState
-+        title="No CI/CD available for this entity"
-+        missing="info"
-+        description="You need to add an annotation to your component if you want to enable CI/CD for it. You can read more
-+        about annotations in Backstage by clicking the button below."
-+        action={
-+          <Button
-+            variant="contained"
-+            color="primary"
-+            href="https://backstage.io/docs/features/software-catalog/well-known-annotations"
-+          >
-+            Read more
-+          </Button>
-+        }
-+      />
-+    </EntitySwitch.Case>
-+  </EntitySwitch>
-+ );
-
-...
-
-const serviceEntityPage = (
-  <EntityLayout>
-    <EntityLayout.Route path="/" title="Overview">
-      {overviewContent}
-    </EntityLayout.Route>
-
-    <EntityLayout.Route path="/ci-cd" title="CI/CD">
-      {cicdContent}
-    </EntityLayout.Route>
-    
-+  <EntityLayout.Route
-+    if={isGithubAvailable}
-+    path="/workflows" title="Workflows">
-+    {WorkflowsContent}
-+  </EntityLayout.Route>
-
-    <EntityLayout.Route path="/api" title="API">
-      <Grid container spacing={3} alignItems="stretch">
-        <Grid item md={6}>
-          <EntityProvidedApisCard />
-        </Grid>
-        <Grid item md={6}>
-          <EntityConsumedApisCard />
-        </Grid>
-      </Grid>
-    </EntityLayout.Route>
-
-    <EntityLayout.Route path="/dependencies" title="Dependencies">
-      <Grid container spacing={3} alignItems="stretch">
-        <Grid item md={6}>
-          <EntityDependsOnComponentsCard variant="gridItem" />
-        </Grid>
-        <Grid item md={6}>
-          <EntityDependsOnResourcesCard variant="gridItem" />
-        </Grid>
-      </Grid>
-    </EntityLayout.Route>
-
-    <EntityLayout.Route path="/docs" title="Docs">
-      {techdocsContent}
-    </EntityLayout.Route>
-  </EntityLayout>
-);
-
-const websiteEntityPage = (
-  <EntityLayout>
-    <EntityLayout.Route path="/" title="Overview">
-      {overviewContent}
-    </EntityLayout.Route>
-
-    <EntityLayout.Route path="/ci-cd" title="CI/CD">
-      {cicdContent}
-    </EntityLayout.Route>
-
-+    <EntityLayout.Route
-+      if={isGithubAvailable}
-+      path="/workflows" title="Workflows">
-+      {WorkflowsContent}
-+    </EntityLayout.Route>
-
-    <EntityLayout.Route path="/dependencies" title="Dependencies">
-      <Grid container spacing={3} alignItems="stretch">
-        <Grid item md={6}>
-          <EntityDependsOnComponentsCard variant="gridItem" />
-        </Grid>
-        <Grid item md={6}>
-          <EntityDependsOnResourcesCard variant="gridItem" />
-        </Grid>
-      </Grid>
-    </EntityLayout.Route>
-
-    <EntityLayout.Route path="/docs" title="Docs">
-      {techdocsContent}
-    </EntityLayout.Route>
-  </EntityLayout>
-);
-
-...
-
-```
-
-
-
-* * *
-
-
-
-### Workflow Cards
-
-For this component, we need to add a special annotation, `github.com/workflows`, like this:
-
-
-
-```diff
-apiVersion: backstage.io/v1alpha1
-kind: Component
-metadata:
-  name: "Example Component"
-  description: "An example Backstage Components"
-  links:
-    - title: Website
-      url: http://backstage.io
-    - title: Documentation
-      url: https://backstage.io/docs
-    - title: Storybook
-      url: https://backstage.io/storybook
-    - title: Discord Chat
-      url: https://discord.com/invite/EBHEGzX
-  annotations:
-    github.com/project-slug: example/ExampleComponent
-    backstage.io/techdocs-ref: dir:.
-+   github.com/workflows: fileName.yaml
-   
-spec:
-  type: website
-  lifecycle: experimental
-  owner: default
-```
-
-
-
-
-The composition of the **annotation** works like this:
-
-
-![image](https://github.com/veecode-platform/platform-backstage-plugins/assets/84424883/290fc11a-020f-449d-bdf7-a0829c452666)
-
-
-
-:information_source:  It's important to note that you can add multiple **workflow paths**, separated by commas, like this:
-
+Required for all catalog components using any GitHub plugin:
 
 ```yaml
-github.com/workflows: filePath.yml,filePath2.yml,filePath3.yml,
+metadata:
+  annotations:
+    github.com/project-slug: my-org/my-repo
 ```
 
+### `github.com/workflows` or `vee.codes/has-github-workflows` (required for Workflow Cards)
 
-The functionality is identical to the workflow listing component, with the main difference being that only the workflows passed via annotation are listed, instead of all the workflows in the repository.
+Pin specific workflows to show in the overview card. The value is a comma-separated list of workflow file paths:
 
-
-
-
-
-![image5](https://github.com/veecode-platform/platform-backstage-plugins/assets/84424883/39ff37fa-6ca6-4a8e-9f23-499353801b53)
-
-
-
-
-
-
-As an indication, we use the cards directly in the component overview, like this:
-
-`packages/app/src/components/catalog/EntityPage.tsx`
-
-
-```diff
-+ import { isGithubWorkflowsAvailable, GithubWorkflowsCard } from '@veecode-platform/backstage-plugin-github-workflows'
-
-....
-
-const overviewContent = (
-  <Grid container spacing={3} alignItems="stretch">
-    {entityWarningContent}
-    <Grid item md={6}>
-      <EntityAboutCard variant="gridItem" />
-    </Grid>
-    <Grid item md={6} xs={12}>
-      <EntityCatalogGraphCard variant="gridItem" height={400} />
-    </Grid>
-
-+    <EntitySwitch>
-+      <EntitySwitch.Case if={isGithubWorkflowsAvailable}>
-+        <Grid item lg={8} xs={12}>
-+            <GithubWorkflowsCard />
-+        </Grid>
-+      </EntitySwitch.Case>
-+    </EntitySwitch>
-    
-    <Grid item md={4} xs={12}>
-      <EntityLinksCard />
-    </Grid>
-    <Grid item md={8} xs={12}>
-      <EntityHasSubcomponentsCard variant="gridItem" />
-    </Grid> 
-  </Grid>
-);
+```yaml
+metadata:
+  annotations:
+    github.com/workflows: deploy.yml,release.yml
 ```
 
-It works like this:
+The plugin renders the Workflow Cards component when either annotation is present. If neither annotation is present, the card does not appear.
 
+---
 
+## Workflows List
 
+The Workflows List component shows all workflows in the repository. It appears in the entity overview and includes:
 
-![image6](https://github.com/veecode-platform/platform-backstage-plugins/assets/84424883/34593129-68bc-44a0-aee7-b1d8c7d12743)
+- Branch selector (filters by branch)
+- Refresh button
+- Table with: workflow name, status, action button, and link to the GitHub run
 
+If a workflow has `inputs` defined under `workflow_dispatch`, the plugin shows a modal to collect those inputs before triggering.
 
+---
 
+## Workflow Cards
 
+The Workflow Cards component shows only the workflows listed in the `github.com/workflows` or `vee.codes/has-github-workflows` annotation. It appears in the entity overview.
 
-In its header we have the select of the repository branches and a refresh button.
+Multiple workflow file paths can be added:
 
-In its body, the workflows that were added via annotation, and each card has its status, workflow name as label and the action button.
+```yaml
+github.com/workflows: build.yml,deploy.yml,release.yml
+```
 
-As with the Workflow list, there are cases of workflows that trigger parameters before releasing their actions, and the card has the same behavior as the Workflow list, it triggers a modal so that the inputs are set:
+---
 
+## Integration with GitHub Actions plugin
 
+The GitHub Workflows plugin integrates with the bundled GitHub Actions plugin (`backstage-community-plugin-github-actions-dynamic`). In the Workflows List, clicking **Logs** opens the corresponding GitHub Actions run. In Workflow Cards, clicking the label navigates to the Actions tab.
 
+To use this integration, also enable the GitHub Actions plugin:
 
-![Captura de tela de 2023-08-14 10-30-03](https://github.com/veecode-platform/platform-backstage-plugins/assets/84424883/83d16247-3b7a-4939-9736-af9ff6a89ae7)
-
-
-
-
-
-![image8](https://github.com/veecode-platform/platform-backstage-plugins/assets/84424883/4051b0d1-a51a-40ae-9924-081d283e3662)
-
-
-
-
-
-The functioning of the actions is also similar, when you click on the action button, it updates the status according to the github response:
-
-
-
-
-![image9](https://github.com/veecode-platform/platform-backstage-plugins/assets/84424883/f9f9e2ad-70ff-468e-b45c-7d5e1f2dc60d)
-
-
-
-
-
-
-### Integration with github actions plugin
-
-For a greater experience, we highlight the use of the default github actions plugin that backstage already provides, where it lists all the runs executed in the repository, and in it are also present all the logs of each action.
-
-In the Workflows List component, integration occurs by clicking on the Logs column:
-
-![image](https://github.com/veecode-platform/platform-backstage-plugins/assets/84424883/81419190-f31b-4b03-bf8c-6d8d037ddfa2)
-
-In the Card component, the integration occurs by clicking under the component label:
-
-![image (1)](https://github.com/veecode-platform/platform-backstage-plugins/assets/84424883/2e502435-2cfd-44ad-b400-3100a6675544)
-
-
-With it correctly installed and available in the **CI-CD** tab, we were able to integrate the triggers of the actions with their logs and all their history:
-
-
-
-
-
-![image10](https://github.com/veecode-platform/platform-backstage-plugins/assets/84424883/3aec7a92-0fdb-4058-9f04-1b8cdb712966)
-
-
+```yaml
+  - package: ./dynamic-plugins/dist/backstage-community-plugin-github-actions-dynamic
+    disabled: false
+    pluginConfig:
+      dynamicPlugins:
+        frontend:
+          backstage-community.plugin-github-actions:
+            mountPoints:
+              - mountPoint: entity.page.ci/cards
+                importName: EntityGithubActionsContent
+                config:
+                  layout:
+                    gridColumn: "1 / -1"
+                  if:
+                    allOf:
+                      - isGithubActionsAvailable
+```

--- a/devportal/plugins/GitLabPipelines.md
+++ b/devportal/plugins/GitLabPipelines.md
@@ -1,178 +1,107 @@
-# Gitlab Pipelines
+---
+sidebar_position: 7
+sidebar_label: GitLab Pipelines
+title: GitLab Pipelines Plugin
+---
 
-The Gitlab-pipelines plugin integrates GitlabCi with its backstage component.
-It offers two approaches:
-- Execute / Cancel a new pipeline, listing the status of the latest pipelines in your project.
-- It offers a list of pipeline executions related to variables, which helps you run individual jobs or groups of jobs.
- 
+# GitLab Pipelines Plugin
 
+The GitLab Pipelines plugin integrates GitLab CI with your DevPortal component. It provides two views:
 
-### Our community
+- **Pipelines List** — lists recent pipelines with the ability to trigger or cancel runs.
+- **GitLab Jobs** — shows individual jobs separated by annotation, useful for triggering specific pipeline stages.
 
-> 💬  **Join Us**
+### Community
+
+> Join our community to resolve questions about our Plugins. We look forward to welcoming you!
 >
-> Join our community to resolve questions about our **Plugins**. We look forward to welcoming you! 
->
->    [Go to Community  🚀](https://github.com/orgs/veecode-platform/discussions)
+> [Go to Community](https://github.com/orgs/veecode-platform/discussions)
 
+---
 
+## Plugin package
 
+The GitLab Pipelines plugin is available as an OCI artifact from `quay.io/veecode/gitlab`. It is **not preloaded** in the distro image — add it via `dynamic-plugins.yaml` or the Marketplace.
 
-## 🚀 Getting started: 
+| OCI Reference | Role |
+|---|---|
+| `oci://quay.io/veecode/gitlab:bs_1.48.4!immobiliarelabs-backstage-plugin-gitlab` | Frontend + backend |
 
-Prerequisites:
-  - Have a Backstage project locally installed, [✔️ How to create a Backstage app 📃](https://backstage.io/docs/getting-started/create-an-app/) .
-  - Set up the catalog and integrate with Gitlab, [✔️ How to set up integration 📃](https://backstage.io/docs/integrations/gitlab/locations) .
-  - Configure Gitlab authentication ✔️.
-  
-##  💻 Installing
+---
 
-If you are using yarn 3.x:
-```bash
-yarn workspace app add @veecode-platform/backstage-plugin-gitlab-pipelines
-```
-If you are using other versions:
-```bash
-yarn add --cwd packages/app @veecode-platform/backstage-plugin-gitlab-pipelines
-```
+## Enabling the plugin
 
-
-
-## ⚙️ Settings
-
-The following steps must be followed to ensure that the plugin works correctly.
-
-
-
-1- **Proxy setup**
-
-1.1 - **Using gitlab auth provider**:
-
-> ℹ️ Make sure you have an github auth provider in your devportal. See how [Add Gitlab Auth Provider 📃](https://backstage.io/docs/auth/gitlab/provider)
-
-As we saw in the link above, the backstage allows you to add authentication by creating an app and adding some information. However, we need to add a few more details:
-
-In the `packages > app > src > identiyProviders.ts` file.
-
-```diff
-import {
-+   gitlabAuthApiRef
-  } from '@backstage/core-plugin-api';
-
-  
-  export const providers = [
-+    {
-+      id: 'gitlab-auth-provider',
-+      title: 'Gitlab',
-+      message: 'Sign in using Gitlab',
-+      apiRef: gitlabAuthApiRef,
-+      enableExperimentalRedirectFlow: true
-+    }
-  ];
-  ```
-
-In the `packages > backend > src > plugins > auth.ts` file.
-
-```diff
-...
-
-export default async function createPlugin(
-  env: PluginEnvironment,
-): Promise<Router> {
-  return await createRouter({
-    logger: env.logger,
-    config: env.config,
-    database: env.database,
-    discovery: env.discovery,
-    tokenManager: env.tokenManager,
-    providerFactories: {
-      ...defaultAuthProviderFactories,
-     
-+      gitlab: providers.gitlab.create({
-+        signIn: {
-+          async resolver({ result: { fullProfile } },
-+          ctx) {
-+            const userId = fullProfile.id;
-+            const userName = fullProfile.displayName
-+            if (!userId) {
-+              throw new Error(
-+                `Gitlab user profile does not contain
-+                  a userId`,
-+              );
-+            }
-+
-+            const userEntityRef = stringifyEntityRef({
-+              kind: 'User',
-+              name: userName,
-+            });
-+            
-+            return ctx.issueToken({
-+              claims: {
-+                sub: userEntityRef,
-+                ent: [userEntityRef],
-+              },
-+            });
-+            
-+          },
-+        },
-+      }),
-    },
-  });
-}
-
-```
-
-In the `app-config.yaml` file:
+Add the following to your `dynamic-plugins.yaml`:
 
 ```yaml
-# add gitlab integration
+plugins:
+  - package: oci://quay.io/veecode/gitlab:bs_1.48.4!immobiliarelabs-backstage-plugin-gitlab
+    disabled: false
+    pluginConfig:
+      dynamicPlugins:
+        frontend:
+          immobiliarelabs.backstage-plugin-gitlab:
+            mountPoints:
+              - mountPoint: entity.page.ci/cards
+                importName: EntityGitlabPipelinesTable
+                config:
+                  layout:
+                    gridColumn: "1 / -1"
+                  if:
+                    allOf:
+                      - isGitlabAvailable
+              - mountPoint: entity.page.overview/cards
+                importName: EntityGitlabJobsTable
+                config:
+                  layout:
+                    gridColumn: "1 / -1"
+                  if:
+                    allOf:
+                      - isGitlabAvailable
+```
+
+Restart DevPortal after saving.
+
+:::note
+Replace `bs_1.48.4` with the Backstage version tag that matches your DevPortal instance. OCI workspace tags must match the deployed Backstage version.
+:::
+
+---
+
+## GitLab integration
+
+Configure the GitLab integration in `app-config.yaml`. The plugin uses these credentials to call the GitLab API server-side:
+
+```yaml
 integrations:
   gitlab:
-    - host: gitlab.com #or gitlab.company.com (depending on your gitlab instance)
+    - host: gitlab.com                        # or your self-hosted GitLab hostname
       token: ${GITLAB_TOKEN}
-      apiBaseUrl: https://gitlab.company.com/api/v4 #Only if the gitlab instance is self-hosted
-...
-# add gitlab auth
+      # apiBaseUrl: https://gitlab.company.com/api/v4   # required for self-hosted instances
+```
+
+For GitLab authentication (sign-in), DevPortal handles it through the GitLab auth provider configured in `app-config.yaml`:
+
+```yaml
 auth:
-  environment: development
   providers:
     gitlab:
-      development:
-        clientId: ${AUTH_GITLAB_CLIENT_ID}
-        clientSecret: ${AUTH_GITLAB_CLIENT_SECRET}
-        audience: ${AUTH_GITLAB_AUDIENCE} #or https://gitlab.company.com (depending on your gitlab instance)
-        #callbackUrl: http://localhost:7007/api/auth/gitlab/handler/frame #optional
+      production:
+        clientId: ${GITLAB_AUTH_CLIENT_ID}
+        clientSecret: ${GITLAB_AUTH_CLIENT_SECRET}
+        audience: https://gitlab.com   # or your self-hosted GitLab URL
 ```
 
-> ℹ️ Remember to set the `${AUTH_GITLAB_CLIENT_ID}` variable with your Gitlab App Client Id and `${AUTH_GITLAB_CLIENT_SECRET}` with the Gitlab App Client Secret value. The `${AUTH_GITLAB_AUDIENCE}` would normally be the url of the deployed gitlab, defaulting to `https://gitlab.com`.
+No code changes to `auth.ts`, `identityProviders.ts`, or `EntityPage.tsx` are needed. DevPortal uses the new backend system and dynamic plugin wiring — all configuration is done in YAML.
+
+---
+
+## Setting up GitLab CI
+
+The plugin triggers new pipelines by setting variables, so your `.gitlab-ci.yml` must use variable conditions to control job execution. This ensures each trigger runs only the intended jobs.
 
 ```yaml
-proxy:
-  endpoints:
-    '/gitlab/api':
-      target: https://gitlab.com/api/v4  #or https://gitlab.company.com/api/v4 (According to the version of your instance)
-      allowedHeaders: ['Authorization', 'Content-Type']
-      headers:
-        Accept: application/json 
-        Content-Type: application/json
-```
-
-> ℹ️ If your gitlab is **self-hosted**, the information must be according to your instance, also respecting the version of the Api used and in the `integration key` the `apiBaseUrl` property is **mandatory**, as well as the `target` of the `proxy` call must contain it.
-
- 
-
-
-
-2- Setting up your GitlabCi
-
-To trigger the pipeline, either completely or by individual jobs, we have chosen to instantiate a new pipeline so that everything is always in the latest build version, rather than adding manual jobs that would invoke states from pipelines that have already been run.
-We therefore need to pay attention to how we configure our `.gitlab_ci.yml`;
-
-See this example:
-
-```yaml
-# List of stages for jobs, and their order of execution
-stages:         
+stages:
   - build
   - deploy
   - start
@@ -183,239 +112,71 @@ variables:
   START_JOB: 'false'
   STOP_JOB: 'false'
 
-build-job:       # Example of standard job for my application
+build-job:
   stage: build
   script:
-    - echo "Compiling the code..."
-    - echo "Compile complete."
+    - echo "Building..."
   rules:
     - if: $DEFAULT_JOB == "true"
 
-deploy-job:      # This job runs in the deploy stage.
-  stage: deploy  # It only runs when *both* jobs in the test stage complete successfully.
-  environment: production
+deploy-job:
+  stage: deploy
   script:
-    - echo "Deploying application..."
-    - echo "Application successfully deployed."
+    - echo "Deploying..."
   rules:
     - if: $DEFAULT_JOB == "true"
 
-start-job:           # Job example for a specific behavior*
+start-job:
   stage: start
   script:
-    - echo "start job..."
+    - echo "Starting..."
   rules:
     - if: $START_JOB == "true"
- 
-stop-job:       # Job example for a specific behavior*
+
+stop-job:
   stage: stop
   script:
-    - echo "stop job..."
+    - echo "Stopping..."
   rules:
     - if: $STOP_JOB == "true"
 ```
 
+---
 
-In the example above, we can highlight two types of jobs: those that are default and are part of the CI-CD cycle, and those that are jobs that have specific behaviors for a task.
+## Annotations
 
-For default jobs, we'll create a standard variable and in all jobs of this type, we'll add the condition that this variable is "true" so that they all run.
+### `gitlab.com/project-slug` (required)
 
-For specific jobs, we will define variables for each one, according to their needs, not forgetting to add the condition that this variable is true so that the job is executed.
-  
-
-
-3- To ensure that the plugin components are rendered, we need to check that the `catalog-info.yaml` of the backstage component has the following annotation: `gitlab.com/project-slug`:
-
-```diff
-apiVersion: backstage.io/v1alpha1
-kind: Component
+```yaml
 metadata:
-  name: "Test"
-  description: "gitlab test"
   annotations:
-+    gitlab.com/project-slug: repo/test
-    backstage.io/techdocs-ref: dir:.
-
-spec:
-  type: service
-  lifecycle: experimental
-  owner: admin
+    gitlab.com/project-slug: my-group/my-project
 ```
 
+### `gitlab.com/jobs` (required for GitLab Jobs component)
 
+Defines the jobs to show in the GitLab Jobs card. Format: `Label:VARIABLE_NAME`, comma-separated:
 
-
-### Pipelines List
-
-
-
-![image](https://github.com/veecode-platform/platform-backstage-plugins/assets/84424883/25bfdbe4-a93c-4b6e-a642-4219842ec4bf)
-
-
-
-The component lists the last pipelines that were executed in the project. In its header we can define the branch, run a new pipeline and also update the table with the refresh button.
-
-The table is divided by "Pipeline ID", which contains the ids of the respective pipelines, followed by their status, the url of the Gitlab interface and the elapsed time of their execution.
-
-When we click on the "run pipeline" button, we'll trigger a modal where we'll insert the jobs variable we set previously. For example, we'll set all the "DEFAULT_JOBS" to run:
-  
-
-![image](https://github.com/veecode-platform/platform-backstage-plugins/assets/84424883/7a53861a-f4e3-4664-81e9-39cb603c4ec1)
-
-
-
-
-Then the jobs in which the variable has been set will be executed in chronological order.
-
-
-
-![image](https://github.com/veecode-platform/platform-backstage-plugins/assets/84424883/c0af4532-c7ae-4433-ae02-83c55ef82504)
-
-
-
-
-As you can see:
-
-
-
- 
-![image](https://github.com/veecode-platform/platform-backstage-plugins/assets/84424883/7dffe0fc-2ace-4bca-bf00-e4f5b3909a5d)
-
-
-
-
-To add it to our component, let's edit the `EntityPage` in the path: `packages/app/src/components/catalog/EntityPage.tsx`:
-
-
-
-```diff
-...
-+ import { GitlabPipelineList, isGitlabAvailable } from '@veecode-platform/backstage-plugin-gitlab-pipelines';
-
-...
-
-const cicdContent = (
-  <EntitySwitch>
-+    <EntitySwitch.Case if={isGitlabAvailable}>
-+      <GitlabPipelineList/>
-+    </EntitySwitch.Case>
-  </EntitySwitch>
-);
-
-...
-```
-
-
-With these changes we are now able to use the **Pipelines List** component.
-
-
-
-
-* * *
-
-
-
-<h3>Gitlab Jobs</h3>
-
-Gitlab Jobs, on the other hand, is a component in which we filter out the jobs we've separated, as in the previous example, which have specific behaviors and aren't part of the standard pipeline flow.
-
-In order for them to be added to our backstage component, we need a special annotation, `gitlab.com/jobs`.
-We follow a different syntax to set the value of this annotation, see:
-
-  
-
-![image](https://github.com/veecode-platform/platform-backstage-plugins/assets/84424883/83e93a07-4dbb-451c-9a49-ef8808ece3ad)
-
-
-
- 
-That way:
-
-
-```diff
-apiVersion: backstage.io/v1alpha1
-kind: Component
+```yaml
 metadata:
-  name: "Test"
-  description: "gitlab test"
   annotations:
-    gitlab.com/project-slug: repo/test
-    backstage.io/techdocs-ref: dir:.
-+    gitlab.com/jobs: 'Deploy:DEFAULT_JOB,Start:START_JOB,Stop:STOP_JOB'
-
-spec:
-  type: service
-  lifecycle: experimental
-  owner: admin
+    gitlab.com/project-slug: my-group/my-project
+    gitlab.com/jobs: 'Deploy:DEFAULT_JOB,Start:START_JOB,Stop:STOP_JOB'
 ```
 
+---
 
-To add it to our backstage component, we need to go back to `packages/app/src/components/catalog/EntityPage.tsx` and add the following code:
+## Pipelines List
 
+Lists recent pipelines for the component's GitLab project. Features:
 
+- Branch selector
+- **Run Pipeline** button — opens a modal to set pipeline variables
+- **Cancel** button on running pipelines
+- Table with: Pipeline ID, status, GitLab URL, elapsed time
 
-```diff
-...
- import {
-  GitlabPipelineList,
-  isGitlabAvailable,
-+ isGitlabJobsAvailable,
-+ GitlabJobs
-  } from '@veecode-platform/backstage-plugin-gitlab-pipelines';
+---
 
-...
+## GitLab Jobs
 
-const overviewContent = (
-  <Grid container spacing={3} alignItems="stretch">
-    {entityWarningContent}
-    <Grid item md={6}>
-      <EntityAboutCard variant="gridItem" />
-    </Grid>
-    <Grid item md={6} xs={12}>
-      <EntityCatalogGraphCard variant="gridItem" height={400} />
-    </Grid>
-
-+    <EntitySwitch>
-+      <EntitySwitch.Case if={isGitlabJobsAvailable}>
-+        <Grid item lg={8} xs={12}>
-+           <GitlabJobs />
-+       </Grid>
-+      </EntitySwitch.Case>
-+    </EntitySwitch>
-    
-    
-    <Grid item md={4} xs={12}>
-      <EntityLinksCard />
-    </Grid>
-  </Grid>
-);
-
-...
-```
-
-
-
-
-We will then have listed all the jobs added to our component's annotation, where the button's Label will be the title of the button component, and the variable will be responsible for triggering the action of each button under the hood:
-
-
-
-
-![image](https://github.com/veecode-platform/platform-backstage-plugins/assets/84424883/cfcee1e1-3f72-4f8d-9cf3-2208f0cd4d9d)
-
-
-
-No need to enter the variable again, just click on run the desired job;
-
-
-
-![image](https://github.com/veecode-platform/platform-backstage-plugins/assets/84424883/0d6a9243-5b23-4209-a808-cd3efc70d6c4)
-
-
-
-And in your gitlab only the job will run in a new pipeline execution:
-
-
-
-![image](https://github.com/veecode-platform/platform-backstage-plugins/assets/84424883/f44615b2-c0dd-4b0e-83e3-7f791193d552)
-
+Shows the individual jobs defined via `gitlab.com/jobs` annotation. Each job is displayed as a button using the annotation label. Clicking a button triggers that job in a new pipeline execution — only the job whose variable is set to `"true"` runs.

--- a/devportal/plugins/Sonar.md
+++ b/devportal/plugins/Sonar.md
@@ -4,167 +4,144 @@ sidebar_label: SonarQube
 title: SonarQube
 ---
 
-# How to Use the SonarQube Plugin in Backstage
+# SonarQube Plugin
 
-The **SonarQube plugin for Backstage** allows you to view code quality metrics—such as bugs, vulnerabilities, test coverage, and duplications—directly in the component catalog. It connects to your organization's SonarQube instance and displays key insights to support continuous inspection of code health.
+The SonarQube plugin for DevPortal displays code quality metrics — bugs, vulnerabilities, test coverage, and duplications — directly in the component catalog. It connects to your SonarQube instance and surfaces key insights inside Backstage.
 
 ---
 
 ## What is SonarQube?
 
-**SonarQube** is an open-source platform for static code analysis. It automatically detects code quality issues such as:
+**SonarQube** is an open-source platform for static code analysis. It detects:
 
-- **Bugs:** errors that can lead to failures.
-- **Vulnerabilities:** security issues like SQL Injection and XSS.
-- **Code Smells:** non-error code that hinders maintainability.
-- **Test Coverage:** how much of your code is covered by automated tests.
-- **Duplications:** repeated blocks of code.
-- **Cyclomatic Complexity:** measures the complexity of functions or methods.
-- **Technical Debt:** estimated effort to fix the detected issues.
+- **Bugs** — errors that can lead to failures
+- **Vulnerabilities** — security issues like SQL injection and XSS
+- **Code Smells** — non-error code that hinders maintainability
+- **Test Coverage** — how much of your code is covered by automated tests
+- **Duplications** — repeated blocks of code
+- **Technical Debt** — estimated effort to fix detected issues
 
 ---
 
-## 🎯 Why Use the Plugin in Backstage?
+## Plugin packages
 
-- **Centralized view** of code quality metrics.
-- **CI/CD pipeline integration** for continuous inspection.
-- **Early failure detection** during development.
-- **Track quality metrics over time.**
-- **Easy access for developers to security and maintenance insights** directly in the Backstage UI.
+| Package | Role |
+|---|---|
+| `backstage-community-plugin-sonarqube` | Frontend — entity card and Code Quality tab |
+| `backstage-community-plugin-sonarqube-backend-dynamic` | Backend — SonarQube API proxy |
+| `backstage-community-plugin-scaffolder-backend-module-sonarqube-dynamic` | Optional — scaffolder actions for SonarQube |
+
+All three are preloaded in the DevPortal image and **disabled by default**. No image rebuild is needed.
 
 ---
 
 ## Prerequisites
 
-To use the SonarQube plugin in Backstage, you need:
-
-- ✅ A configured and up-to-date Backstage instance.
-- ✅ A SonarQube instance (community, self-hosted, or cloud).
-- ✅ A SonarQube workspace with your Organization and configured projects.
+- A running SonarQube instance (community, self-hosted, or SonarCloud)
+- A SonarQube API key (user token or analysis token) with read access
 
 ---
 
-## Plugin Installation
+## Enabling the plugin
 
-### Backend
+Add the following to your `dynamic-plugins.yaml`:
 
-1. **Install the dependency:**
+```yaml
+plugins:
+  - package: ./dynamic-plugins/dist/backstage-community-plugin-sonarqube-backend-dynamic
+    disabled: false
 
-```bash
-yarn --cwd packages/backend add @backstage-community/plugin-sonarqube-backend
+  - package: ./dynamic-plugins/dist/backstage-community-plugin-sonarqube
+    disabled: false
+    pluginConfig:
+      dynamicPlugins:
+        frontend:
+          backstage-community.plugin-sonarqube:
+            entityTabs:
+              - path: /code-quality
+                title: Code Quality
+                mountPoint: entity.page.code-quality
+                config:
+                  if:
+                    allOf:
+                      - isSonarQubeAvailable
+            mountPoints:
+              - mountPoint: entity.page.code-quality/cards
+                importName: SonarQubeRelatedEntitiesOverview
+                config:
+                  layout:
+                    gridColumn: "1 / -1"
+                  if:
+                    allOf:
+                      - isSonarQubeAvailable
+              - mountPoint: entity.page.overview/cards
+                importName: EntitySonarQubeCard
+                config:
+                  layout:
+                    gridColumnEnd:
+                      lg: span 4
+                      md: span 6
+                      xs: span 12
+                  if:
+                    allOf:
+                      - isSonarQubeAvailable
+
+  # Optional: scaffolder actions
+  - package: ./dynamic-plugins/dist/backstage-community-plugin-scaffolder-backend-module-sonarqube-dynamic
+    disabled: false
 ```
 
-1. Add the plugin in `index.ts`:
+Restart DevPortal after saving. Via the Marketplace UI you can click **Enable** instead of editing YAML manually.
 
-```ts
-import { createBackend } from '@backstage/backend-defaults';
-const backend = createBackend();
-// ... other features
-backend.add(import('@backstage-community/plugin-sonarqube-backend'));
-backend.start();
-```
+---
 
-1. Configure the variables in **`app-config.yaml`:**
-- For a single instance:
+## App configuration
+
+Add SonarQube connection details to `app-config.yaml`.
+
+### Single instance
 
 ```yaml
 sonarqube:
   baseUrl: ${SONARQUBE_BASE_URL}
-  instanceKey: ${SONARQUBE_INSTANCE_KEY}
   apiKey: ${SONARQUBE_API_KEY}
 ```
 
-- For multiple instances:
+`baseUrl` defaults to `https://sonarcloud.io` if omitted.
+
+### Multiple instances
 
 ```yaml
 sonarqube:
   instances:
     - name: default
       baseUrl: ${SONARQUBE_BASE_URL}
-      instanceKey: ${SONARQUBE_INSTANCE_KEY}
       apiKey: ${SONARQUBE_API_KEY}
     - name: specialProject
-      baseUrl: ${SONARQUBE_BASE_UR2L}
-      instanceKey: ${SONARQUBE_INSTANCE_KEY2}
-      apiKey: ${SONARQUBE_API_KEY2}
+      baseUrl: ${SONARQUBE_BASE_URL_2}
+      apiKey: ${SONARQUBE_API_KEY_2}
 ```
+
+The valid top-level fields are `baseUrl`, `externalBaseUrl`, `apiKey`, and `instances`. There is no `instanceKey` field — that field does not exist in the schema and is silently ignored if present.
 
 ---
 
-### Frontend
+## Connecting a component to SonarQube
 
-1. Install the dependencies:
-
-```bash
-yarn --cwd packages/app add @backstage-community/plugin-sonarqube @backstage-community/plugin-sonarqube-react
-```
-
-1. Add the components in **`EntityPage.tsx`:**
-
-```tsx
-import { EntitySonarQubeCard } from '@backstage-community/plugin-sonarqube';
-import { isSonarQubeAvailable } from '@backstage-community/plugin-sonarqube-react';
-
-const overviewContent = (
-  <Grid container spacing={3} alignItems="stretch">
-    <Grid item md={6}>
-      <EntityAboutCard variant="gridItem" />
-    </Grid>
-    <EntitySwitch>
-      <EntitySwitch.Case if={isSonarQubeAvailable}>
-        <Grid item md={6}>
-          <EntitySonarQubeCard variant="gridItem" />
-        </Grid>
-      </EntitySwitch.Case>
-    </EntitySwitch>
-  </Grid>
-);
-```
-
-1. **If using the new frontend:**
-- In `App.tsx`, add:
-
-```ts
-import sonarQubePlugin from '@backstage-community/plugin-sonarqube/alpha';
-
-export const app = createApp({
-  features: [
-    // other plugins
-    sonarQubePlugin,
-  ],
-});
-```
-
----
-
-## How to Connect a Project to the Plugin
-
-In your repository, edit the `catalog-info.yaml` file of the corresponding entity and add the annotation with the SonarQube project key:
+Add the `sonarqube.org/project-key` annotation in the component's `catalog-info.yaml`:
 
 ```yaml
 apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
-  name: nest-api
-  title: NestJs API
-  description: |
-    Demo of vulnerabilities and security in the project.
+  name: my-api
   annotations:
-    github.com/project-slug: veecode-homolog/nest-api
-    sonarqube.org/project-key: veecode-homolog_nest-api
+    github.com/project-slug: my-org/my-api
+    sonarqube.org/project-key: my-org_my-api
 spec:
   type: service
   owner: user:default/admin
   lifecycle: production
-
 ```
 
----
-
-## Example: Daily Usage
-
-During the development of a Java API, the team sets up SonarQube in the Jenkins pipeline. With every new push, the code is analyzed:
-
-- If bugs or security issues are found, the build fails.
-- The team receives instant feedback and fixes the issues before proceeding to production.
-- Backstage displays a panel with the updated quality indicators for the project.
+The project key value must match the project key in your SonarQube instance. The SonarQube card and Code Quality tab only appear on entities where `isSonarQubeAvailable` is true (i.e., where this annotation is set).

--- a/devportal/plugins/adding.md
+++ b/devportal/plugins/adding.md
@@ -19,8 +19,8 @@ The in-portal Marketplace is the simplest path — no YAML editing required.
 1. Open your Backstage instance and click **Marketplace** in the sidebar
 2. Search for the plugin you want (e.g., GitLab, Tech Insights, AWS ECS)
 3. Click **Enable** on the plugin card
-4. A *Restart Pending* badge appears in the customer portal
-5. In the customer portal, click **Restart** — allow ~2 minutes for the pod to come back up
+4. A *Restart Pending* badge appears in the DevPortal header
+5. Restart the instance so the change takes effect — on self-hosted deployments restart the pod/container yourself (e.g. `kubectl rollout restart`); on the VeeCode SaaS the customer portal exposes a **Restart** button. Allow ~2 minutes for the instance to come back up.
 6. The plugin appears in its configured location (sidebar entry, entity tab, etc.)
 
 :::warning
@@ -123,7 +123,7 @@ Add the plugin to the `global.dynamic.plugins` array in your `values.yaml`:
 global:
   dynamic:
     plugins:
-      - package: 'oci://quay.io/veecode/gitlab:bs_1.49.4!immobiliarelabs-backstage-plugin-gitlab'
+      - package: 'oci://quay.io/veecode/gitlab:bs_1.48.4!immobiliarelabs-backstage-plugin-gitlab'
         disabled: false
         pluginConfig: {}
 ```

--- a/devportal/plugins/adding.md
+++ b/devportal/plugins/adding.md
@@ -93,7 +93,7 @@ If you are using VKDR to manage your local DevPortal instance, add plugins using
 ```bash
 vkdr devportal install \
   --github-token=$GITHUB_TOKEN \
-  --install-samples \
+  --samples \
   --merge ./my-plugins.yaml
 ```
 

--- a/devportal/plugins/adding.md
+++ b/devportal/plugins/adding.md
@@ -71,13 +71,20 @@ oci://quay.io/veecode/<workspace>:bs_<backstage-version>!<plugin-name>
 
 Available workspaces on `quay.io/veecode`:
 
-| Workspace | Plugins |
-|---|---|
-| `gitlab` | GitLab frontend + backend (immobiliare) |
-| `tech-insights` | Tech Insights frontend, backend, jsonfc |
-| `aws-ecs` | AWS ECS frontend + backend |
-| `mcp-integrations` | MCP extras (catalog, techdocs, scaffolder) |
-| `backstage` | MCP actions backend |
+| Workspace | Plugins | Tag |
+|---|---|---|
+| `gitlab` | GitLab frontend + backend (immobiliare) | `bs_1.48.4` |
+| `tech-insights` | Tech Insights frontend, backend, jsonfc | `bs_1.48.4` |
+| `aws-ecs` | AWS ECS frontend + backend | `bs_1.48.4` |
+| `mcp-integrations` | MCP extras (catalog, techdocs, scaffolder) | `bs_1.49.4` |
+| `backstage` | MCP actions backend | `bs_1.49.4` |
+| `mcp-chat` | MCP Chat frontend + backend | `bs_1.49.4` |
+
+:::note
+The workspace tag must match the Backstage version of your DevPortal instance. The examples above reflect current published tags; MCP workspaces are on `bs_1.49.4` while others are on `bs_1.48.4`. The workspace table above is not exhaustive — there are 60+ workspaces in the export-overlays pipeline. Use the Marketplace for the complete catalog.
+:::
+
+For a complete list of bundled (preloaded) plugins that do not require an OCI reference, see [Bundled Plugins](./bundled).
 
 ### VKDR (local setup)
 

--- a/devportal/plugins/bundled/_category_.json
+++ b/devportal/plugins/bundled/_category_.json
@@ -1,0 +1,4 @@
+{
+    "label": "Bundled Plugins",
+    "position": 3
+}

--- a/devportal/plugins/bundled/about.md
+++ b/devportal/plugins/bundled/about.md
@@ -1,0 +1,55 @@
+---
+sidebar_position: 5
+sidebar_label: About
+title: About Plugin
+---
+
+# About Plugin
+
+The About plugin displays version and instance information for the DevPortal deployment. It is accessible at `/about` under the **Admin** menu section.
+
+**Status:** Always loaded (preInstalled). No `dynamic-plugins.yaml` entry required.
+
+---
+
+## Packages
+
+| Package | Role |
+|---|---|
+| `veecode-platform-backstage-plugin-about-dynamic` | Frontend — About page at `/about` |
+| `veecode-platform-backstage-plugin-about-backend-dynamic` | Backend — serves version and instance metadata |
+
+---
+
+## What it does
+
+- Shows the installed DevPortal version
+- Shows the Backstage version the instance is running on
+- Shows enabled plugins and runtime status
+- Accessible to admin users under the Admin menu
+
+---
+
+## Mount point configuration (from `dynamic-plugins.default.yaml`)
+
+```yaml
+pluginConfig:
+  dynamicPlugins:
+    frontend:
+      veecode-platform.backstage-plugin-about:
+        appIcons:
+          - name: aboutIcon
+            importName: AboutIcon
+        dynamicRoutes:
+          - path: /about
+            importName: AboutPage
+            menuItem:
+              icon: aboutIcon
+              text: About
+              enabled: true
+        menuItems:
+          about:
+            parent: admin
+            title: About
+            icon: aboutIcon
+```

--- a/devportal/plugins/bundled/azure-devops.md
+++ b/devportal/plugins/bundled/azure-devops.md
@@ -1,0 +1,77 @@
+---
+sidebar_position: 9
+sidebar_label: Azure DevOps
+title: Azure DevOps Plugin
+---
+
+# Azure DevOps Plugin
+
+The Azure DevOps plugin displays Azure Pipelines builds and Azure Pull Requests in catalog entity pages.
+
+**Status:** Preloaded in the DevPortal image, **disabled by default**. Enable via `dynamic-plugins.yaml` or Marketplace.
+
+---
+
+## Package
+
+`backstage-community-plugin-azure-devops-dynamic`
+
+---
+
+## What it does
+
+- **CI tab**: Shows Azure Pipelines build results via `EntityAzurePipelinesContent`
+- **Pull Requests tab**: Shows open Azure PRs via `EntityAzurePullRequestsContent`
+- Both components only render when `isAzureDevOpsAvailable` is true (i.e., the required annotation is present)
+
+---
+
+## Enabling the plugin
+
+```yaml
+plugins:
+  - package: ./dynamic-plugins/dist/backstage-community-plugin-azure-devops-dynamic
+    disabled: false
+    pluginConfig:
+      dynamicPlugins:
+        frontend:
+          backstage-community.plugin-azure-devops:
+            mountPoints:
+              - mountPoint: entity.page.ci/cards
+                importName: EntityAzurePipelinesContent
+                config:
+                  layout:
+                    gridColumn: "1 / -1"
+                  if:
+                    allOf:
+                      - isAzureDevOpsAvailable
+              - mountPoint: entity.page.pull-requests/cards
+                importName: EntityAzurePullRequestsContent
+                config:
+                  layout:
+                    gridColumn: "1 / -1"
+                  if:
+                    allOf:
+                      - isAzureDevOpsAvailable
+```
+
+---
+
+## App configuration
+
+```yaml
+azureDevOps:
+  host: dev.azure.com
+  token: ${AZURE_TOKEN}
+  organization: ${AZURE_ORGANIZATION}
+```
+
+---
+
+## Required annotation
+
+```yaml
+metadata:
+  annotations:
+    dev.azure.com/project-repo: my-project/my-repo
+```

--- a/devportal/plugins/bundled/github-actions.md
+++ b/devportal/plugins/bundled/github-actions.md
@@ -1,0 +1,72 @@
+---
+sidebar_position: 8
+sidebar_label: GitHub Actions
+title: GitHub Actions Plugin
+---
+
+# GitHub Actions Plugin
+
+The GitHub Actions plugin displays GitHub Actions workflow run history in the CI tab of catalog entities. It is the standard Backstage community plugin for GitHub Actions integration.
+
+**Status:** Preloaded in the DevPortal image, **disabled by default**. Enable via `dynamic-plugins.yaml` or Marketplace.
+
+---
+
+## Package
+
+`backstage-community-plugin-github-actions-dynamic`
+
+---
+
+## What it does
+
+- Adds a **CI** tab to entity pages showing recent GitHub Actions workflow runs
+- Displays run status, duration, branch, and commit
+- Links to the GitHub Actions run for logs and details
+- Shows only for entities with the `github.com/project-slug` annotation
+
+---
+
+## Enabling the plugin
+
+```yaml
+plugins:
+  - package: ./dynamic-plugins/dist/backstage-community-plugin-github-actions-dynamic
+    disabled: false
+    pluginConfig:
+      dynamicPlugins:
+        frontend:
+          backstage-community.plugin-github-actions:
+            mountPoints:
+              - mountPoint: entity.page.ci/cards
+                importName: EntityGithubActionsContent
+                config:
+                  layout:
+                    gridColumn: "1 / -1"
+                  if:
+                    allOf:
+                      - isGithubActionsAvailable
+```
+
+---
+
+## Required annotation
+
+```yaml
+metadata:
+  annotations:
+    github.com/project-slug: my-org/my-repo
+```
+
+---
+
+## GitHub integration
+
+The plugin uses `integrations.github` in `app-config.yaml`. Ensure a GitHub token or GitHub App is configured:
+
+```yaml
+integrations:
+  github:
+    - host: github.com
+      token: ${GITHUB_TOKEN}
+```

--- a/devportal/plugins/bundled/global-header.md
+++ b/devportal/plugins/bundled/global-header.md
@@ -1,0 +1,49 @@
+---
+sidebar_position: 3
+sidebar_label: Global Header
+title: VeeCode Global Header Plugin
+---
+
+# VeeCode Global Header Plugin
+
+The VeeCode Global Header plugin provides the unified top navigation bar across all DevPortal pages. It includes search, notifications, starred items, theme toggle, and the user profile dropdown.
+
+**Status:** Always loaded (preInstalled). No `dynamic-plugins.yaml` entry required.
+
+---
+
+## Package
+
+`veecode-platform-plugin-veecode-global-header-dynamic`
+
+---
+
+## What it does
+
+The header mounts at `application/header` and adds the following components to the `global.header/component` mount point:
+
+| Component | Mount point priority | Description |
+|---|---|---|
+| `SearchComponent` | 100 | Global search bar |
+| `StarredDropdown` | 70 | Quick access to starred entities |
+| `ToggleThemeButton` | 75 | Light/dark theme switcher |
+| `NotificationButton` | 60 | Notifications bell |
+| `PendingChangesButton` | 55 | (from Pending Changes plugin) Restart-pending indicator |
+| `Divider` | 90 | Visual separator |
+| `ProfileDropdown` | 10 | User avatar with Settings and Sign Out |
+
+---
+
+## Profile dropdown items
+
+| Item | Link |
+|---|---|
+| Settings | `/settings` |
+| My profile | User entity page |
+| Sign out | Auth sign-out |
+
+---
+
+## Customization
+
+Additional components can be injected into the header by adding entries to the `global.header/component` mount point in `dynamic-plugins.yaml`. See [Wiring a Frontend Plugin](../development/wiring) for the configuration syntax.

--- a/devportal/plugins/bundled/homepage.md
+++ b/devportal/plugins/bundled/homepage.md
@@ -36,4 +36,8 @@ pluginConfig:
         dynamicRoutes:
           - path: /
             importName: VeecodeHomepagePage
+            config:
+              props:
+                width: 1500
+                height: 800
 ```

--- a/devportal/plugins/bundled/homepage.md
+++ b/devportal/plugins/bundled/homepage.md
@@ -1,0 +1,39 @@
+---
+sidebar_position: 2
+sidebar_label: Homepage
+title: VeeCode Homepage Plugin
+---
+
+# VeeCode Homepage Plugin
+
+The VeeCode Homepage plugin provides the customizable landing page for DevPortal. It mounts at the root route `/` and replaces the default Backstage home page.
+
+**Status:** Always loaded (preInstalled). No `dynamic-plugins.yaml` entry required.
+
+---
+
+## Package
+
+`veecode-platform-plugin-veecode-homepage-dynamic`
+
+---
+
+## What it does
+
+- Renders the DevPortal landing page at `/`
+- Supports customization of content, quick-links, and branding through app configuration
+- Integrates with the Global Header for consistent navigation
+
+---
+
+## Mount point configuration (from `dynamic-plugins.default.yaml`)
+
+```yaml
+pluginConfig:
+  dynamicPlugins:
+    frontend:
+      veecode-platform.plugin-veecode-homepage:
+        dynamicRoutes:
+          - path: /
+            importName: VeecodeHomepagePage
+```

--- a/devportal/plugins/bundled/index.md
+++ b/devportal/plugins/bundled/index.md
@@ -1,0 +1,62 @@
+---
+sidebar_position: 0
+sidebar_label: Bundled Plugins
+title: Bundled Plugin Catalog
+---
+
+# Bundled Plugin Catalog
+
+DevPortal ships with a set of **preinstalled dynamic plugins** baked into the distro image. They are available immediately — no download or rebuild needed. Most are **disabled by default** and are enabled by adding an entry to `dynamic-plugins.yaml` (or via the Marketplace).
+
+A few core plugins (`preInstalled: true` in `dynamic-plugins.default.yaml`) are always loaded — they power the UI shell, navigation, and marketplace itself.
+
+---
+
+## Always-on plugins (preInstalled, no YAML entry needed)
+
+| Plugin | Package | What it does |
+|---|---|---|
+| [RBAC](./rbac) | `backstage-community-plugin-rbac` | Role-based access control UI at `/rbac` |
+| [Homepage](./homepage) | `veecode-platform-plugin-veecode-homepage-dynamic` | Customizable landing page at `/` |
+| [Global Header](./global-header) | `veecode-platform-plugin-veecode-global-header-dynamic` | Unified top navigation bar (search, notifications, profile) |
+| [Tech Radar](./tech-radar) | `backstage-community-plugin-tech-radar-dynamic` + `backstage-community-plugin-tech-radar-backend-dynamic` | Technology adoption radar at `/tech-radar` |
+| [About](./about) | `veecode-platform-backstage-plugin-about-dynamic` + `veecode-platform-backstage-plugin-about-backend-dynamic` | DevPortal version and instance info at `/about` |
+| [Marketplace](./marketplace) | `devportal-marketplace-frontend-dynamic` + `devportal-marketplace-backend-dynamic-dynamic` | In-portal plugin discovery and enable/disable UI at `/marketplace` |
+| [Pending Changes](./pending-changes) | `devportal-pending-changes-dynamic` | Header badge indicating pending restart when plugins are enabled/disabled via Marketplace |
+| Catalog Extensions Module | `red-hat-developer-hub-backstage-plugin-catalog-backend-module-extensions` | Registers Extension/Package/Collection entity kinds; reads `extensions-install.yaml` |
+
+---
+
+## Disabled-by-default plugins (bundled, require enabling)
+
+| Plugin | Package | What it does |
+|---|---|---|
+| [Kubernetes](../kubernetes) | `backstage-plugin-kubernetes-dynamic` | Kubernetes workload viewer on entity pages |
+| [GitHub Actions](./github-actions) | `backstage-community-plugin-github-actions-dynamic` | GitHub Actions run history on entity CI tab |
+| [GitHub Workflows](../GitHubWorkflows) | `veecode-platform-backstage-plugin-github-workflows-dynamic` + backend | Manual workflow trigger cards on entity overview |
+| [Azure DevOps](./azure-devops) | `backstage-community-plugin-azure-devops-dynamic` | Azure Pipelines and Pull Requests on entity pages |
+| [Jenkins](./jenkins) | `backstage-community-plugin-jenkins` + `backstage-community-plugin-jenkins-backend-dynamic` | Jenkins build status on entity CI tab |
+| [SonarQube](../Sonar) | `backstage-community-plugin-sonarqube` + `backstage-community-plugin-sonarqube-backend-dynamic` | Code quality metrics on entity overview and Code Quality tab |
+| Security Insights | `roadiehq-backstage-plugin-security-insights-dynamic` | GitHub Dependabot alerts and security advisories |
+| GitHub Insights | `roadiehq-backstage-plugin-github-insights-dynamic` | GitHub code insights on entity pages |
+| Global FAB | `red-hat-developer-hub-backstage-plugin-global-floating-action-button-dynamic` | Configurable floating action button |
+
+---
+
+## OCI-only plugins (not in distro image, enable via dynamic-plugins.yaml)
+
+These must be downloaded at startup from `quay.io/veecode`. See [Adding Plugins](../adding) for configuration details.
+
+| Plugin | OCI Reference |
+|---|---|
+| MCP Actions Backend | `oci://quay.io/veecode/backstage:bs_1.49.4!backstage-plugin-mcp-actions-backend` |
+| MCP Catalog Extras | `oci://quay.io/veecode/mcp-integrations:bs_1.49.4!red-hat-developer-hub-backstage-plugin-software-catalog-mcp-extras` |
+| MCP TechDocs Extras | `oci://quay.io/veecode/mcp-integrations:bs_1.49.4!red-hat-developer-hub-backstage-plugin-techdocs-mcp-extras` |
+| MCP Scaffolder Extras | `oci://quay.io/veecode/mcp-integrations:bs_1.49.4!red-hat-developer-hub-backstage-plugin-scaffolder-mcp-extras` |
+| MCP Chat Backend | `oci://quay.io/veecode/mcp-chat:bs_1.49.4!backstage-community-plugin-mcp-chat-backend` |
+| MCP Chat Frontend | `oci://quay.io/veecode/mcp-chat:bs_1.49.4!backstage-community-plugin-mcp-chat` |
+| GitLab Pipelines | `oci://quay.io/veecode/gitlab:bs_1.48.4!immobiliarelabs-backstage-plugin-gitlab` |
+
+---
+
+For plugins not listed here (Grafana, Vault, Tech Insights, and others), see [Finding Plugins](../finding) and [Adding Plugins](../adding).

--- a/devportal/plugins/bundled/jenkins.md
+++ b/devportal/plugins/bundled/jenkins.md
@@ -1,0 +1,90 @@
+---
+sidebar_position: 10
+sidebar_label: Jenkins
+title: Jenkins Plugin
+---
+
+# Jenkins Plugin
+
+The Jenkins plugin displays Jenkins build status in catalog entity pages.
+
+**Status:** Preloaded in the DevPortal image, **disabled by default**. Enable via `dynamic-plugins.yaml` or Marketplace.
+
+---
+
+## Packages
+
+| Package | Role |
+|---|---|
+| `backstage-community-plugin-jenkins` | Frontend — entity CI tab card |
+| `backstage-community-plugin-jenkins-backend-dynamic` | Backend — Jenkins API proxy |
+
+Both must be enabled together.
+
+---
+
+## What it does
+
+- Adds a **CI** tab entry showing Jenkins builds via `EntityJenkinsContent`
+- Displays build status, duration, and link to Jenkins
+- Only renders for entities with `isJenkinsAvailable` true
+
+---
+
+## Enabling the plugin
+
+```yaml
+plugins:
+  - package: ./dynamic-plugins/dist/backstage-community-plugin-jenkins-backend-dynamic
+    disabled: false
+    pluginConfig:
+      jenkins:
+        instances:
+          - name: default
+            baseUrl: ${JENKINS_URL}
+            username: ${JENKINS_USERNAME}
+            apiKey: ${JENKINS_TOKEN}
+
+  - package: ./dynamic-plugins/dist/backstage-community-plugin-jenkins
+    disabled: false
+    pluginConfig:
+      dynamicPlugins:
+        frontend:
+          backstage-community.plugin-jenkins:
+            mountPoints:
+              - mountPoint: entity.page.ci/cards
+                importName: EntityJenkinsContent
+                config:
+                  layout:
+                    gridColumn: "1 / -1"
+                  if:
+                    allOf:
+                      - isJenkinsAvailable
+```
+
+---
+
+## App configuration
+
+Jenkins connection details are supplied via the backend plugin's `pluginConfig`:
+
+```yaml
+jenkins:
+  instances:
+    - name: default
+      baseUrl: ${JENKINS_URL}        # e.g. https://jenkins.company.com
+      username: ${JENKINS_USERNAME}
+      apiKey: ${JENKINS_TOKEN}       # Jenkins API token (not password)
+```
+
+Multiple Jenkins instances are supported — add additional entries to the `instances` array and reference them with `jenkins.com/host` annotation.
+
+---
+
+## Required annotation
+
+```yaml
+metadata:
+  annotations:
+    jenkins.io/job-full-name: my-folder/my-job
+```

--- a/devportal/plugins/bundled/marketplace.md
+++ b/devportal/plugins/bundled/marketplace.md
@@ -1,0 +1,69 @@
+---
+sidebar_position: 6
+sidebar_label: Marketplace
+title: Marketplace Plugin
+---
+
+# Marketplace Plugin
+
+The Marketplace plugin is the in-portal interface for discovering, enabling, and disabling dynamic plugins without editing YAML files. It is accessible at `/marketplace` in the sidebar.
+
+**Status:** Always loaded (preInstalled). No `dynamic-plugins.yaml` entry required.
+
+---
+
+## Packages
+
+| Package | Role |
+|---|---|
+| `devportal-marketplace-frontend-dynamic` | Frontend — Marketplace UI at `/marketplace` |
+| `devportal-marketplace-backend-dynamic-dynamic` | Backend — plugin catalog and install state management |
+| `red-hat-developer-hub-backstage-plugin-catalog-backend-module-extensions` | Catalog module — registers Extension/Package/Collection entity kinds |
+
+The DevPortal Marketplace is a fork of the Red Hat Developer Hub Extensions plugin, customized for VeeCode DevPortal.
+
+---
+
+## What it does
+
+- Displays all available plugins (bundled + OCI-published)
+- Shows which plugins are enabled or disabled
+- **Enable** button saves the plugin selection to `extensions-install.yaml`
+- **Pending Changes** badge appears in the header when a restart is needed to apply changes
+- After restart, enabled plugins load from `extensions-install.yaml`
+
+---
+
+## How plugin persistence works
+
+When you enable a plugin via the Marketplace:
+
+1. The backend writes an entry to `/app/extensions-install.yaml`
+2. A **Pending Changes** indicator appears in the header
+3. On the next pod restart, `install-dynamic-plugins.py` reads `extensions-install.yaml` (included in `dynamic-plugins.yaml`) and installs the selected plugins
+
+This means Marketplace selections **persist across restarts** once the pod is restarted.
+
+---
+
+## Mount point configuration (from `dynamic-plugins.default.yaml`)
+
+```yaml
+pluginConfig:
+  dynamicPlugins:
+    frontend:
+      devportal.marketplace-frontend:
+        appIcons:
+          - name: pluginsIcon
+            importName: PluginsIcon
+        dynamicRoutes:
+          - path: /marketplace
+            importName: DynamicExtensionsPluginRouter
+            menuItem:
+              icon: pluginsIcon
+              text: Marketplace
+        menuItems:
+          marketplace:
+            title: Marketplace
+            icon: pluginsIcon
+```

--- a/devportal/plugins/bundled/pending-changes.md
+++ b/devportal/plugins/bundled/pending-changes.md
@@ -1,0 +1,45 @@
+---
+sidebar_position: 7
+sidebar_label: Pending Changes
+title: Pending Changes Plugin
+---
+
+# Pending Changes Plugin
+
+The Pending Changes plugin adds a badge to the Global Header indicating that plugin configuration changes have been saved but not yet applied. It signals that a pod restart is needed to activate the changes.
+
+**Status:** Always loaded (preInstalled). No `dynamic-plugins.yaml` entry required.
+
+---
+
+## Package
+
+`devportal-pending-changes-dynamic`
+
+---
+
+## What it does
+
+- Polls for pending plugin changes every 30 seconds (configurable)
+- Displays a badge next to the Notifications bell in the header when changes are pending
+- Clicking the badge navigates to the restart/apply flow in the customer portal
+
+---
+
+## Mount point configuration (from `dynamic-plugins.default.yaml`)
+
+```yaml
+pluginConfig:
+  dynamicPlugins:
+    frontend:
+      devportal.pending-changes:
+        mountPoints:
+          - mountPoint: global.header/component
+            importName: PendingChangesButton
+            config:
+              priority: 55
+              props:
+                pollingIntervalMs: 30000
+```
+
+To change the polling interval, override `pollingIntervalMs` in your `dynamic-plugins.yaml`.

--- a/devportal/plugins/bundled/rbac.md
+++ b/devportal/plugins/bundled/rbac.md
@@ -1,0 +1,63 @@
+---
+sidebar_position: 1
+sidebar_label: RBAC
+title: RBAC Plugin
+---
+
+# RBAC Plugin
+
+The RBAC plugin provides a UI for managing role-based access control policies in DevPortal. It adds a `/rbac` route under the **Admin** menu section.
+
+**Status:** Always loaded (preInstalled). No `dynamic-plugins.yaml` entry required.
+
+---
+
+## Package
+
+`backstage-community-plugin-rbac`
+
+---
+
+## What it does
+
+- Displays all roles (`role:default/admin`, `role:default/developer`, `role:default/viewer`) and their members
+- Shows permission policies per role
+- Allows admins to create, edit, and delete roles and policies through the UI
+- Reads and writes the RBAC policy CSV file at runtime
+
+---
+
+## Access
+
+The RBAC UI is accessible at `/rbac` and appears in the sidebar under **Admin** for users with the `role:default/admin` role.
+
+---
+
+## Default roles
+
+| Role | Purpose |
+|---|---|
+| `role:default/admin` | Full administrative access, including RBAC management |
+| `role:default/developer` | Standard developer access |
+| `role:default/viewer` | Read-only access |
+
+The distro adds `extensions.plugin.configuration.read` and `extensions.plugin.configuration.write` permissions for the admin role via `rbac-policy-extensions.csv`.
+
+---
+
+## App configuration
+
+RBAC is configured in `app-config.yaml` under `permission.rbac`:
+
+```yaml
+permission:
+  enabled: true
+  rbac:
+    policies-csv-file: /app/rbac-policy.csv
+    pluginsWithPermission:
+      - catalog
+      - scaffolder
+      - kubernetes
+```
+
+See [Permissions and RBAC](../../rbac/permissions) for full configuration details.

--- a/devportal/plugins/bundled/tech-radar.md
+++ b/devportal/plugins/bundled/tech-radar.md
@@ -1,0 +1,59 @@
+---
+sidebar_position: 4
+sidebar_label: Tech Radar
+title: Tech Radar Plugin
+---
+
+# Tech Radar Plugin
+
+The Tech Radar plugin provides a visual technology adoption radar, helping teams communicate which technologies are recommended, in trial, on hold, or being phased out.
+
+**Status:** Always loaded (preInstalled). No `dynamic-plugins.yaml` entry required.
+
+---
+
+## Packages
+
+| Package | Role |
+|---|---|
+| `backstage-community-plugin-tech-radar-dynamic` | Frontend — Tech Radar page at `/tech-radar` |
+| `backstage-community-plugin-tech-radar-backend-dynamic` | Backend — serves radar data |
+
+---
+
+## What it does
+
+- Renders an interactive radar visualization at `/tech-radar`
+- Sidebar entry appears under the Tech Radar menu item
+- Data is served by the backend plugin from a configured data source
+
+---
+
+## Mount point configuration (from `dynamic-plugins.default.yaml`)
+
+```yaml
+pluginConfig:
+  dynamicPlugins:
+    frontend:
+      backstage-community.plugin-tech-radar:
+        appIcons:
+          - name: techRadar
+            importName: TechRadarIcon
+        dynamicRoutes:
+          - path: /tech-radar
+            importName: TechRadarPage
+            menuItem:
+              icon: techRadar
+              text: Tech Radar
+              textKey: menuItem.techRadar
+            config:
+              props:
+                width: 1500
+                height: 800
+```
+
+---
+
+## Customizing radar data
+
+By default the Tech Radar backend serves a built-in sample dataset. To customize the data, implement a `TechRadarApi` by providing a custom radar data endpoint. Refer to the [Backstage Tech Radar plugin documentation](https://github.com/backstage/community-plugins/tree/main/workspaces/tech-radar) for API details.

--- a/devportal/plugins/cicd.md
+++ b/devportal/plugins/cicd.md
@@ -1,53 +1,60 @@
 ---
 sidebar_position: 15
-sidebar_label: CI/CD 
-title: CI/CD Plugin Tutorial
+sidebar_label: CI/CD Plugins
+title: CI/CD Plugins
 ---
 
-### How to Use the CI/CD Plugin in DevPortal
+# CI/CD Plugins
 
-The **CI/CD Plugin** in DevPortal simplifies and automates continuous integration and continuous delivery processes, improving team collaboration and ensuring high-quality code. This tutorial will walk you through the steps to effectively use the plugin.
+DevPortal ships several separate CI/CD plugins, each integrating with a specific CI/CD platform. There is no single "CI/CD Plugin" — each platform has its own bundled plugin that must be enabled individually.
 
----
-
-### Why Use the CI/CD Plugin?
-
-1. **Automation:** Automates code integration and deployment, reducing human error and saving time.
-2. **Code Quality:** Automatically runs tests and code analysis on each commit to catch issues early.
-3. **Collaboration:** Enhances coordination among development, QA, and operations teams, offering real-time pipeline updates and issue resolution.
-4. **Continuous Delivery:** Facilitates frequent, reliable deployments for faster feature and bug fix releases.
-
-# Steps to Use the CI/CD Plugin
-
-### Step 1: Access the DevPortal
-
-- Log in to the DevPortal using your credentials.
-- Once logged in, access the available features and plugins tailored to your project.
+All CI/CD plugins described here are **preloaded in the DevPortal image and disabled by default**. Enable them via `dynamic-plugins.yaml` or the Marketplace — no support contact required.
 
 ---
 
-### Step 2: Navigate to the Catalog
+## Available CI/CD plugins
 
-- Open the sidebar menu and select **Catalog**.
-- Use filters like **APIs** or **Components** to narrow down the list of items.
-- Quickly find APIs or components relevant to your CI/CD pipeline.r.
+| Plugin | Platform | Package |
+|---|---|---|
+| [GitHub Actions](./bundled/github-actions) | GitHub Actions workflow runs | `backstage-community-plugin-github-actions-dynamic` |
+| [GitHub Workflows](./GitHubWorkflows) | Manual GitHub workflow trigger + cards | `veecode-platform-backstage-plugin-github-workflows-dynamic` |
+| [Jenkins](./bundled/jenkins) | Jenkins build status | `backstage-community-plugin-jenkins` + backend |
+| [Azure DevOps](./bundled/azure-devops) | Azure Pipelines + Pull Requests | `backstage-community-plugin-azure-devops-dynamic` |
+| [GitLab Pipelines](./GitLabPipelines) | GitLab CI pipeline trigger and status | OCI: `oci://quay.io/veecode/gitlab:bs_1.48.4!immobiliarelabs-backstage-plugin-gitlab` |
 
-### Step 3: Select the Configured CI/CD Plugin
+---
 
-- Choose the API or component that has the CI/CD plugin configured.
-- If the plugin is not yet installed or configured, contact the [VeeCode Platform Support Team](https://platform.vee.codes/contact-us/)for assistance.
-    - Learn more about support plans [here](https://platform.vee.codes/compare-plans/).
+## How CI/CD results appear
 
-### **Step 4: Interact with the CI/CD Plugin**
+The bundled GitHub Actions, Jenkins, and Azure DevOps plugins mount their content in the **CI** entity tab (`entity.page.ci/cards`). The tab appears automatically on entities that have the relevant annotation and `disabled: false` in the plugin configuration.
 
-1. **Access the Plugin:**
-    - Go to the list of plugins or view the **Overview** tab of the selected API/component to locate the CI/CD plugin.
-2. **Pipeline Monitoring:**
-    - Check the pipeline status, recent runs, and deployment history.
-    - Review logs for detailed information on each stage.
-3. **Perform Actions:**
-    - Start new pipeline runs.
-    - Re-run pipelines that failed.
-    - Approve or reject manual deployment stages when required.
+GitHub Workflows mounts as an **overview card** (`entity.page.overview/cards`) rather than in the CI tab, and is controlled by the `github.com/workflows` or `vee.codes/has-github-workflows` annotation.
 
-Using the CI/CD Plugin in DevPortal enhances automation, collaboration, and code quality, enabling reliable software delivery. It ensures that your team operates efficiently and delivers value to users through fast and secure deployments.
+---
+
+## Quick enable: GitHub Actions
+
+The simplest CI/CD plugin to enable for GitHub-hosted projects:
+
+```yaml
+plugins:
+  - package: ./dynamic-plugins/dist/backstage-community-plugin-github-actions-dynamic
+    disabled: false
+    pluginConfig:
+      dynamicPlugins:
+        frontend:
+          backstage-community.plugin-github-actions:
+            mountPoints:
+              - mountPoint: entity.page.ci/cards
+                importName: EntityGithubActionsContent
+                config:
+                  layout:
+                    gridColumn: "1 / -1"
+                  if:
+                    allOf:
+                      - isGithubActionsAvailable
+```
+
+Add `github.com/project-slug: my-org/my-repo` to the component's `catalog-info.yaml` and the CI tab will appear.
+
+For other platforms, follow the links in the table above for full enable instructions.

--- a/devportal/plugins/development/bootstrap.md
+++ b/devportal/plugins/development/bootstrap.md
@@ -82,7 +82,7 @@ You get for every created plugin a new package at `plugins/your-plugin-id` folde
 
 ## Next steps
 
-Proceed to the next steps based on the type of plugin you created. At the end of this guide we will cover packahging and distribution of your plugin.
+Proceed to the next steps based on the type of plugin you created. At the end of this guide we will cover packaging and distribution of your plugin.
 
 ## Troubleshooting tips
 

--- a/devportal/plugins/development/loading.md
+++ b/devportal/plugins/development/loading.md
@@ -4,13 +4,33 @@ sidebar_label: Loading
 title: "Loading a Dynamic Plugin"
 ---
 
-Dynamic plugins can be loaded by VeeCode DevPortal at start time. They are usually published to a private npm registry, and the DevPortal instance will load them from there according to the configuration.
+Dynamic plugins can be loaded by VeeCode DevPortal at start time. They are usually published to a private npm registry or OCI registry, and the DevPortal instance will load them from there according to the configuration.
 
 ## Configuration
 
-VeeCode DevPortal is usually deployed with its Helm chart, and the configuration is done in the `values.yaml` file, under the `global.dynamic.plugins` section:
+There are two configuration surfaces depending on your deployment model:
+
+### `dynamic-plugins.yaml` (distro container / SaaS)
+
+For the standard DevPortal container (docker-compose, SaaS, or VKDR), edit `dynamic-plugins.yaml` directly:
 
 ```yaml
+plugins:
+  # npm plugin
+  - package: '@yourorg/yourplugin@x.y.z'
+    disabled: false
+    integrity: sha512-xxxxxxxxx
+  # preloaded plugin (uses path relative to the dynamic-plugins directory)
+  - package: ./dynamic-plugins/dist/another-plugin-dynamic
+    disabled: false
+```
+
+### Helm `values.yaml` (Kubernetes deployment)
+
+For Kubernetes deployments using the VeeCode Helm chart, configure plugins under `global.dynamic.plugins`:
+
+```yaml
+global:
   dynamic:
     plugins:
       # npm plugin
@@ -21,6 +41,8 @@ VeeCode DevPortal is usually deployed with its Helm chart, and the configuration
       - package: ./dynamic-plugins/dist/another-plugin-dynamic
         disabled: false
 ```
+
+Both surfaces accept the same plugin entry format. The `dynamic-plugins.yaml` approach is recommended for non-Helm deployments.
 
 ## Private npm registry
 
@@ -52,7 +74,7 @@ kubectl create secret generic veecode-devportal-dynamic-plugins-npmrc \
 
 Dynamic plugins have the ability to wire themselves to the DevPortal instance configuration. **This is a critical feature** because unlike static plugins they cannot imply in code changes to the host Backstage project.
 
-Backwend plugins should be detected and loaded automatically, but frontend plugins must be wired by `pluginConfig:` to the DevPortal instance.
+Backend plugins should be detected and loaded automatically, but frontend plugins must be wired by `pluginConfig:` to the DevPortal instance.
 
 All dynamic plugins can bring their own settings in the `pluginConfig:` field:
 

--- a/devportal/plugins/development/wiring.md
+++ b/devportal/plugins/development/wiring.md
@@ -34,7 +34,7 @@ global:
 
 ## Testing with VKDR
 
-Our [local DevPortal setup](../../installation-guide/local-setup) using `vkdr` can be used to validate locally the wiring of a dynamic frontend plugin.
+Our [local DevPortal setup](../../installation-guide/vkdr-local/vkdr-setup) using `vkdr` can be used to validate locally the wiring of a dynamic frontend plugin.
 
 ### Steps
 
@@ -43,7 +43,7 @@ What you need:
 - A local npm registry (run [Verdaccio](https://verdaccio.org/) at local port 4873)
 - Publish the frontend plugin to Verdaccio (as described [here](/devportal/plugins/development/packaging#publish-a-dynamic-plugin))
 - Obtain the SHA integrity signature of the published plugin
-- A local `vkdr` cluster with DevPortal properly installed - check the [local DevPortal setup](../../installation-guide/local-setup) guide for more info.
+- A local `vkdr` cluster with DevPortal properly installed - check the [local DevPortal setup](../../installation-guide/vkdr-local/vkdr-setup) guide for more info.
 
 ### Verdaccio
 
@@ -64,7 +64,7 @@ npm view @your-org/plugin-my-front-plugin-dynamic@x.y.z --registry http://localh
 ```
 
 :::important
-The integrity signature is a SHA512 hash of the plugin package. It is required for the dynamimc plugin to be loaded.
+The integrity signature is a SHA512 hash of the plugin package. It is required for the dynamic plugin to be loaded.
 :::
 
 ### VKDR Infra Up

--- a/devportal/plugins/development/wiring.md
+++ b/devportal/plugins/development/wiring.md
@@ -111,7 +111,7 @@ vkdr devportal install --github-token $GITHUB_TOKEN \
 ```
 
 :::note
-This command installs DebPortal with the extra plugin wiring. It also installs a few sample apps and configures DevPortal to rely on Verdaccio as an external npm registry.
+This command installs DevPortal with the extra plugin wiring. It also installs a few sample apps and configures DevPortal to rely on Verdaccio as an external npm registry.
 :::
 
 ### Open DevPortal (VKDR)

--- a/devportal/plugins/finding.md
+++ b/devportal/plugins/finding.md
@@ -4,14 +4,36 @@ sidebar_label: Finding Plugins
 title: Finding Plugins
 ---
 
-Currently there are a few online Backstage plugin catalogs today.
+# Finding Plugins
 
-- 🔥[VeeCode Backstage Plugins](https://platform.vee.codes/en/resources/)🔥: **this is our curated list of (mostly) VeeCode-mantained and some third-party Backstage plugins. It is intended to evolve into a marketplace-like experience, where we list both bundled and downloadable plugins and how to enable them in your DevPortal instance.**
+## In-portal Marketplace (recommended)
 
-- [Backstage Plugin Registry](https://backstage.io/plugins): this is the official Backstage plugin registry, but it is not exactly a marketplace-like experience. Some plugins are just links to GitHub repositories, others are not even published as a package. Almost all of them assume you will statically link them to your Backstage custom build as a developer.
+The fastest way to find and enable plugins is the **Marketplace** built into DevPortal. Navigate to **Marketplace** in the sidebar to browse available plugins, see which are enabled or disabled, and enable them with one click — no YAML editing required.
 
-- [Roadie Backstage Plugins](https://roadie.io/backstage/plugins/): this is a curated list of (mostly) Roadie-mantained Backstage plugins. It is almost a marketplace-like experience, but the "no-code" approach is proprietary for their closed-source product. When using their plugins you will need to statically link them to your Backstage custom build as a developer (this is referred as "Self-hosted Backstage" in Roadie docs).
+The Marketplace shows:
+- All bundled plugins (preloaded in the image, ready to enable)
+- OCI-published plugins available for download at startup
 
-:::important
-Please understand that Backstage plugin ecossystem is still in its early stages and there are no clear standards for publishing plugins, specially dynamic plugins. We at VeeCode are committed to provide a "no-code" marketplace-like experience for our customers and we are working hard to make it happen.
+See [Bundled Plugins](./bundled) for a complete list of what ships with DevPortal.
+
+---
+
+## Online catalogs
+
+For plugins beyond the bundled set:
+
+- [VeeCode Backstage Plugins](https://platform.vee.codes/en/resources/): VeeCode-curated list of maintained and third-party plugins, with OCI references for DevPortal.
+
+- [Backstage Plugin Registry](https://backstage.io/plugins): The official Backstage plugin registry. Most entries assume a static Backstage custom build; for DevPortal use, you need a dynamic plugin version (OCI or npm).
+
+- [Roadie Backstage Plugins](https://roadie.io/backstage/plugins/): Roadie-curated list. The self-hosted path requires static linking unless a dynamic-compatible version is available.
+
+:::note
+The Backstage plugin ecosystem does not yet have a universal standard for publishing dynamic plugins. VeeCode publishes dynamic-ready OCI artifacts for a growing set of community plugins. Check the Marketplace first before sourcing from external registries.
 :::
+
+---
+
+## Checking what is already bundled
+
+Review `dynamic-plugins.default.yaml` in the DevPortal distro for the definitive list of bundled plugins and their package names. All entries with `preInstalled: true` are always active; entries with `disabled: true` are available but need enabling.

--- a/devportal/plugins/grafana.md
+++ b/devportal/plugins/grafana.md
@@ -1,64 +1,83 @@
 ---
 sidebar_position: 12
-sidebar_label: Grafana 
-title: Grafana Plugin Tutorial
+sidebar_label: Grafana
+title: Grafana Plugin
 ---
 
-### How to Use the Grafana Plugin in DevPortal
+# Grafana Plugin
 
-The **Grafana Plugin** in DevPortal empowers you to monitor and visualize metrics, logs, and traces from your services. This tutorial will guide you through the steps to use it effectively, leveraging its observability features to enhance your system's performance and reliability.
+The Grafana plugin for Backstage embeds Grafana dashboards and alert panels in entity pages, giving developers direct observability access from the catalog.
 
----
-
-### Why Use the Grafana Plugin?
-
-- **Real-Time Visualization:** Monitor system behavior with interactive dashboards.
-- **Customization:** Create tailored panels for specific needs.
-- **Alerting:** Set thresholds to receive notifications for potential issues.
-- **User-Friendly Interface:** Easy to set up and use within DevPortal.
+:::note
+The Grafana plugin is **not bundled** in the DevPortal image. It must be added as an external dynamic plugin via `dynamic-plugins.yaml` or the Marketplace. No support plan is required — the plugin is a standard Backstage community plugin available publicly.
+:::
 
 ---
 
-# Step-by-Step Guide
+## Adding the plugin
 
-### Step 1: Accessing DevPortal
+### Via Marketplace
 
-1. Log in to **DevPortal** with your credentials.
-2. Gain access to all functionalities and plugins for your project.
+Search for "Grafana" in the DevPortal Marketplace and click **Enable**. The Marketplace handles the OCI reference and mount point configuration automatically.
+
+### Via `dynamic-plugins.yaml`
+
+Add the Grafana plugin from the community OCI registry. Check the [Marketplace](../plugins/finding) or the [Backstage Plugin Registry](https://backstage.io/plugins) for the current OCI reference and workspace tag that matches your DevPortal's Backstage version.
+
+A typical entry looks like:
+
+```yaml
+plugins:
+  - package: oci://quay.io/veecode/<workspace>:<tag>!roadiehq-backstage-plugin-grafana
+    disabled: false
+    pluginConfig:
+      dynamicPlugins:
+        frontend:
+          roadiehq.backstage-plugin-grafana:
+            mountPoints:
+              - mountPoint: entity.page.overview/cards
+                importName: EntityGrafanaDashboardsCard
+                config:
+                  layout:
+                    gridColumn: "1 / -1"
+                  if:
+                    allOf:
+                      - isGrafanaAvailable
+```
+
+Replace `<workspace>` and `<tag>` with the values that match your instance. See [Adding Plugins](./adding) for details on the OCI artifact format.
 
 ---
 
-### Step 2: Navigating to the Catalog
+## App configuration
 
-1. In the sidebar menu, select the **"Catalog"** tab.
-2. Filter items by selecting **"API"** or **"Component"**.
-3. Narrow your search to locate the desired item quickly.
-
----
-
-### Step 3: Selecting the Configured Item
-
-1. Browse the list for an API or component with the Grafana plugin configured.
-2. Unsure about the setup? Contact **VeeCode Platform** support or review support plan options at [platform.vee.codes](https://platform.vee.codes/compare-plans/).
+```yaml
+grafana:
+  # The base URL of your Grafana instance
+  domain: ${GRAFANA_URL}
+  # Optional: Grafana API key for fetching dashboards programmatically
+  # unifiedAlerting: true   # set to true if using Grafana Unified Alerting
+```
 
 ---
 
-### Step 4: Accessing the Grafana Plugin
+## Required annotation
 
-1. Open the selected API or component.
-2. In the "Overview" section of the configured plugins, locate the **Grafana Plugin**.
-3. Explore its pre-configured dashboards for initial insights.
+Add the following annotation to the component's `catalog-info.yaml`:
+
+```yaml
+metadata:
+  annotations:
+    grafana/dashboard-selector: "tags @> 'my-service'"
+    grafana/alert-label-selector: "service=my-service"
+```
+
+- `grafana/dashboard-selector` — a Grafana tag expression that filters dashboards to show
+- `grafana/alert-label-selector` — a label selector for Grafana alerts
 
 ---
 
-### Step 5: Interacting with Grafana
+## References
 
-Grafana offers diverse functionalities to monitor and analyze your system:
-
-- **Metrics Monitoring:** View response times, throughput, and error rates.
-- **Log Analysis:** Search and examine logs for errors, delays, or failures.
-- **Tracing:** Track request execution across services to pinpoint latency or errors.
-- **Customization:** Modify pre-configured panels or create new ones tailored to your needs.
-
-The **Grafana Plugin** is a robust observability tool in DevPortal, simplifying system monitoring and troubleshooting. By following this guide, you can unlock valuable insights into your services' performance and stability.
-
+- [Roadie Grafana plugin on GitHub](https://github.com/RoadieHQ/roadie-backstage-plugins/tree/main/plugins/frontend/backstage-plugin-grafana)
+- [Adding Plugins to DevPortal](./adding)

--- a/devportal/plugins/kubernetes.md
+++ b/devportal/plugins/kubernetes.md
@@ -1,60 +1,115 @@
 ---
 sidebar_position: 13
-sidebar_label: Kubernetes 
-title: Kubernetes Plugin Tutorial
+sidebar_label: Kubernetes
+title: Kubernetes Plugin
 ---
 
-### How to Use the Kubernetes Plugin in DevPortal
+# Kubernetes Plugin
 
-The **Kubernetes Plugin** in DevPortal simplifies the management of your Kubernetes clusters by allowing you to deploy, monitor, and scale workloads directly from the DevPortal dashboard.
+The Kubernetes plugin for Backstage displays the live state of Kubernetes resources — pods, deployments, services, and more — for a catalog entity. It appears as a **Kubernetes tab on the entity page** (not a sidebar item).
 
----
-
-### Benefits of Using the Kubernetes Plugin
-
-1. **Simplified Management:** Manage clusters easily from a centralized dashboard.
-2. **Real-time Monitoring:** Access metrics and live status of your workloads.
-3. **Improved Collaboration:** Facilitate seamless cooperation between development and operations teams.
+The plugin is **preloaded in the DevPortal image** and disabled by default. No image rebuild or support contact is needed to enable it.
 
 ---
 
-# Steps to Use the Kubernetes Plugin
+## Plugin package
 
-### Step 1: Access the Kubernetes Dashboard
+| Package | Role |
+|---|---|
+| `backstage-plugin-kubernetes-dynamic` | Frontend — entity Kubernetes tab |
 
-1. **Request Access:** Contact VeeCode Platform’s support team to enable the Kubernetes Plugin.
-2. **Confirm Plan Level:** Ensure your support plan includes access to the plugin. Visit [VeeCode Plans](https://platform.vee.codes/compare-plans/) for details.
-
----
-
-### Step 2: Using the Kubernetes Plugin
-
-1. **Install the Plugin:**
-    - If not already installed, add the Kubernetes Plugin to your project. Contact support for help if needed.
-2. **Navigate to the Dashboard:**
-    - Access the Kubernetes icon in the sidebar to open the dashboard.
-3. **Explore Features:**
-    - View running **pods** and **deployments** within your clusters.
-    - Use provided tools to scale, update, or delete resources.
+The backend for Kubernetes is a **static plugin** compiled into the DevPortal base image. The frontend is a dynamic plugin that must be enabled in `dynamic-plugins.yaml`.
 
 ---
 
-### Step 3: Viewing and Managing Your Workloads
+## Enabling the plugin
 
-1. **Access Workloads:** View a detailed list of pods and deployments running across your clusters.
-2. **Perform Actions:**
-    - Scale resources to handle traffic demands.
-    - Update configurations or images.
-    - Delete unused resources to optimize performance.
+Add the following to your `dynamic-plugins.yaml`:
+
+```yaml
+plugins:
+  - package: ./dynamic-plugins/dist/backstage-plugin-kubernetes-dynamic
+    disabled: false
+    pluginConfig:
+      dynamicPlugins:
+        frontend:
+          backstage.plugin-kubernetes:
+            entityTabs:
+              - path: /kubernetes
+                title: Kubernetes
+                mountPoint: entity.page.kubernetes
+                config:
+                  if:
+                    allOf:
+                      - hasAnnotation: backstage.io/kubernetes-label-selector
+            mountPoints:
+              - mountPoint: entity.page.kubernetes/cards
+                importName: EntityKubernetesContent
+                config:
+                  layout:
+                    gridColumn: "1 / -1"
+                  if:
+                    allOf:
+                      - hasAnnotation: backstage.io/kubernetes-label-selector
+```
+
+Restart DevPortal after saving. Via the Marketplace UI you can click **Enable** instead of editing YAML manually.
+
+The **Kubernetes tab only appears on entities that have the `backstage.io/kubernetes-label-selector` annotation**. Entities without the annotation will not show the tab.
 
 ---
 
-### Step 4: Monitor Your Workloads in Real-time
+## App configuration
 
-1. **View Metrics:** Monitor key performance indicators, including resource utilization and uptime.
-2. **Identify Issues:** Use logs and metrics to troubleshoot and address any anomalies promptly.
-3. **Optimize Performance:** Adjust resource allocation as needed for improved efficiency.
+Configure the Kubernetes backend in `app-config.yaml`:
 
-The **Kubernetes Plugin** in DevPortal empowers teams to manage Kubernetes workloads with efficiency and ease. It streamlines workflows, fosters collaboration, and ensures optimal system performance.
+```yaml
+kubernetes:
+  serviceLocatorMethod:
+    type: 'multiTenant'
+  clusterLocatorMethods:
+    - type: 'config'
+      clusters:
+        - name: ${K8S_CLUSTER_NAME}
+          url: ${K8S_CLUSTER_URL}
+          authProvider: 'serviceAccount'
+          skipTLSVerify: true
+          serviceAccountToken: ${K8S_CLUSTER_TOKEN}
+```
 
-For more assistance, contact the VeeCode Platform support team or explore available plans on their [website](https://platform.vee.codes/compare-plans/).
+Multiple clusters are supported — add additional entries to the `clusters` array.
+
+---
+
+## Required annotation
+
+Add the `backstage.io/kubernetes-label-selector` annotation to the component's `catalog-info.yaml`. The value is a Kubernetes label selector that identifies the workloads belonging to this component:
+
+```yaml
+metadata:
+  annotations:
+    backstage.io/kubernetes-label-selector: 'app=my-service,environment=production'
+```
+
+The Kubernetes tab and its content only render when this annotation is present on the entity.
+
+---
+
+## What the plugin shows
+
+The Kubernetes tab displays:
+
+- Running **pods** (with status, restarts, and age)
+- **Deployments** and their rollout status
+- **ReplicaSets**, **StatefulSets**, and **DaemonSets**
+- **Services** and **Ingresses**
+- Pod logs (click a pod for live log streaming)
+
+The plugin does not add a top-level sidebar item — it is accessible only via the entity's Kubernetes tab.
+
+---
+
+## References
+
+- [Backstage Kubernetes plugin documentation](https://backstage.io/docs/features/kubernetes/)
+- [Kubernetes backend configuration](https://backstage.io/docs/features/kubernetes/configuration)

--- a/devportal/plugins/plugins.md
+++ b/devportal/plugins/plugins.md
@@ -83,7 +83,11 @@ Example: TechDocs plugin.
 
 **Bundled dynamic plugins** are not linked to DevPortal as a part of its build process, but stored in a "dynamic-plugins" folder included in DevPortal distro. DevPortal configuration can be set to load these plugins at start time. These plugins can also be referred as "pre-installed plugins".
 
-Example: VeeCode "home" and "header" plugin.
+Examples of always-active preInstalled plugins: VeeCode Homepage, Global Header, RBAC, Tech Radar, About, Marketplace, and Pending Changes.
+
+Examples of bundled-but-disabled plugins: Kubernetes, GitHub Actions, Azure DevOps, Jenkins, SonarQube, GitHub Workflows.
+
+For the complete list with package names and enable instructions, see the [Bundled Plugin Catalog](./bundled).
 
 ### Downloaded plugins
 

--- a/devportal/plugins/techdocs.md
+++ b/devportal/plugins/techdocs.md
@@ -1,58 +1,159 @@
 ---
 sidebar_position: 10
-sidebar_label: Tech Docs 
-title: Tech Docs Plugin Tutorial
+sidebar_label: Tech Docs
+title: Tech Docs
 ---
 
-### How to Use the **Tech Docs Plugin** in DevPortal
+# TechDocs
 
-The **Tech Docs Plugin** in DevPortal simplifies the process of creating, managing, and publishing technical documentation. Follow this step-by-step guide to utilize its full potential.
-
----
-
-### Why Use the Tech Docs Plugin?
-
-- **Clear Documentation:** Create structured, easy-to-understand guides for your projects.
-- **Better Collaboration:** Centralized documentation improves teamwork.
-- **Boosted Productivity:** Access organized, searchable resources.
-- **Enhanced User Experience:** Provide users with comprehensive support.
+TechDocs is a **docs-as-code** system built into Backstage. Documentation lives as Markdown files in your source repository and is rendered inside DevPortal. There is no in-portal editor, "New Page" button, or "Publish" button — content is written, committed, and built from the repository.
 
 ---
 
-# Step-by-Step Guide
+## How it works
 
-### Step 1: Accessing the Tech Docs Plugin
-
-1. Log in to the **DevPortal** with your credentials.
-2. Navigate to the sidebar menu.
-3. Select the **"Tech Docs"** tab to open the Tech Docs dashboard.
+1. A repository contains a `mkdocs.yml` configuration file and a `docs/` directory with Markdown content.
+2. The `catalog-info.yaml` for the component carries a `backstage.io/techdocs-ref` annotation pointing to the docs source.
+3. When a user opens the **Docs** tab in DevPortal, TechDocs builds (or serves pre-built) documentation using MkDocs.
 
 ---
 
-### Step 2: Creating a New Documentation Page
+## Repository requirements
 
-1. Click on **“New Page”** in the dashboard.
-2. Use the built-in editor to craft your page:
-    - Add text, headings, and images.
-    - Utilize formatting options for engaging and readable content.
-3. Save your progress to ensure no data is lost.
+Every component that uses TechDocs must have:
+
+### `mkdocs.yml` (at the repository root)
+
+```yaml
+site_name: My Component
+docs_dir: docs
+nav:
+  - Home: index.md
+```
+
+### `docs/index.md` (minimum content)
+
+```markdown
+# My Component
+
+Welcome to the documentation for My Component.
+```
+
+### `catalog-info.yaml` annotation
+
+```yaml
+metadata:
+  annotations:
+    backstage.io/techdocs-ref: dir:.
+```
+
+`dir:.` means the `mkdocs.yml` is in the same directory as `catalog-info.yaml`. Use `dir:./path/to/docs` if your docs live in a subdirectory.
 
 ---
 
-### Step 3: Editing and Managing Documentation
+## Builder and publisher configuration
 
-1. From the Tech Docs dashboard:
-    - Organize your pages into **categories and subcategories**.
-    - Assign **tags** for improved searchability.
-2. Customize the appearance of your documentation to align with your project's branding.
+TechDocs requires a **builder** (how docs are generated) and a **publisher** (where generated docs are stored). The default configuration uses `local` for both, which is suitable for local development but not recommended for production.
+
+```yaml
+# app-config.yaml (default — suitable for development only)
+techdocs:
+  builder: 'local'
+  generator:
+    runIn: 'local'
+  publisher:
+    type: 'local'
+```
+
+With `builder: 'local'` and `publisher: 'local'`, DevPortal regenerates docs on demand and stores them in the container's local filesystem. **Docs are lost when the pod restarts.**
+
+### Local builder toolchain requirement
+
+When `builder: 'local'` and `generator.runIn: 'local'` are set, the DevPortal container runs `mkdocs` directly. The container image includes the required Python toolchain. If you are running DevPortal outside the official image, install:
+
+```bash
+pip install mkdocs mkdocs-techdocs-core
+```
 
 ---
 
-### Step 4: Publishing Documentation
+## Production setup: external builder + cloud storage
 
-1. Once your documentation is finalized, click on the **“Publish”** button.
-2. The content will become accessible to your audience, enhancing their understanding and interaction with your project.
+For production deployments, generate docs in CI and store them in a cloud bucket. This avoids per-request generation overhead and persists docs across restarts.
 
-The **Tech Docs Plugin** in DevPortal is an essential tool for maintaining high-quality technical documentation. By following this guide, you can improve user engagement, streamline team collaboration, and enhance your project's overall success.
+### Step 1: Generate docs in CI
 
+Add a step to your CI pipeline using the `techdocs-cli`:
 
+```bash
+npx @techdocs/cli generate --source-dir . --output-dir ./site
+npx @techdocs/cli publish --publisher-type awsS3 --storage-name my-techdocs-bucket --entity default/Component/my-api
+```
+
+### Step 2: Configure an external publisher
+
+#### Amazon S3
+
+```yaml
+techdocs:
+  builder: 'external'
+  publisher:
+    type: 'awsS3'
+    awsS3:
+      bucketName: ${TECHDOCS_S3_BUCKET_NAME}
+      region: ${AWS_REGION}
+      # credentials: use IAM role or AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY env vars
+```
+
+#### Google Cloud Storage
+
+```yaml
+techdocs:
+  builder: 'external'
+  publisher:
+    type: 'googleGcs'
+    googleGcs:
+      bucketName: ${TECHDOCS_GCS_BUCKET_NAME}
+      # credentials: use Application Default Credentials or set GOOGLE_APPLICATION_CREDENTIALS
+```
+
+#### Azure Blob Storage
+
+```yaml
+techdocs:
+  builder: 'external'
+  publisher:
+    type: 'azureBlobStorage'
+    azureBlobStorage:
+      containerName: ${TECHDOCS_AZURE_CONTAINER_NAME}
+      credentials:
+        accountName: ${AZURE_ACCOUNT_NAME}
+        accountKey: ${AZURE_ACCOUNT_KEY}
+```
+
+With `builder: 'external'`, DevPortal only reads from the bucket — it does not attempt to generate docs itself.
+
+---
+
+## Static plugin status
+
+TechDocs is a **static plugin** in DevPortal — the frontend and backend are compiled into the base image and always active. No entry in `dynamic-plugins.yaml` is needed to enable TechDocs. Configuration in `app-config.yaml` is sufficient.
+
+---
+
+## Common issues
+
+| Symptom | Likely cause | Fix |
+|---|---|---|
+| Docs tab shows "No docs found" | Missing `mkdocs.yml` or `docs/index.md` | Add `mkdocs.yml` and at least one Markdown file under `docs/` |
+| Docs tab shows "No docs found" | Missing or wrong `backstage.io/techdocs-ref` annotation | Check annotation value — use `dir:.` for docs at repo root |
+| Docs disappear after pod restart | `publisher.type: local` in production | Switch to S3/GCS/Azure Blob and generate docs in CI |
+| MkDocs build error | Missing `mkdocs-techdocs-core` plugin | Add `plugins: - techdocs-core` to `mkdocs.yml` and ensure the package is installed |
+
+---
+
+## References
+
+- [Backstage TechDocs documentation](https://backstage.io/docs/features/techdocs/)
+- [TechDocs CLI](https://backstage.io/docs/features/techdocs/cli)
+- [MkDocs documentation](https://www.mkdocs.org/)

--- a/devportal/plugins/vault.md
+++ b/devportal/plugins/vault.md
@@ -1,51 +1,89 @@
 ---
 sidebar_position: 14
 sidebar_label: Vault
-title: Vault Plugin Tutorial
+title: Vault Plugin
 ---
 
-### How to Use the Vault Plugin in DevPortal
+# Vault Plugin
 
-The **Vault Plugin** in DevPortal is designed to securely store and manage sensitive data like passwords, API keys, and other secrets. This tutorial will guide you through the steps to effectively use this plugin.
+The Vault plugin for Backstage displays HashiCorp Vault secrets associated with a catalog entity, allowing developers to view secret paths and metadata directly from the DevPortal UI.
 
----
-
-### Benefits of Using the Vault Plugin
-
-1. **Enhanced Security:** Ensures sensitive data is encrypted and accessible only to authorized users.
-2. **Centralized Management:** Simplifies control and monitoring of secrets in a single interface.
-3. **Streamlined Distribution:** Provides an easy-to-use interface for securely sharing secrets with applications and team members.
+:::note
+The Vault plugin is **not bundled** in the DevPortal image. It must be added as an external dynamic plugin via `dynamic-plugins.yaml` or the Marketplace. No special support plan is required — the plugin is a standard Backstage community plugin available publicly.
+:::
 
 ---
 
-# Steps to Use the Vault Plugin
+## Adding the plugin
 
-### Step 1: Getting Started with the Vault Plugin
+### Via Marketplace
 
-1. **Set Up a Vault Instance:**
-    - Ensure a Vault instance is active. Follow Vault's official documentation to set one up if needed.
-2. **Verify Support Plan:**
-    - Access to the Vault Plugin requires a specific support level. Visit [VeeCode Plans](https://platform.vee.codes/compare-plans/) for more details or upgrades.
-3. **Integrate with DevPortal:**
-    - Install the Vault Plugin in your DevPortal project.
-    - Configure it by specifying the Vault endpoint and providing the necessary authentication credentials.
+Search for "Vault" in the DevPortal Marketplace and click **Enable**.
+
+### Via `dynamic-plugins.yaml`
+
+Check the [Marketplace](../plugins/finding) or the [Backstage Plugin Registry](https://backstage.io/plugins) for the current OCI reference and workspace tag that matches your DevPortal's Backstage version.
+
+A typical entry looks like:
+
+```yaml
+plugins:
+  - package: oci://quay.io/veecode/<workspace>:<tag>!backstage-community-plugin-vault
+    disabled: false
+    pluginConfig:
+      dynamicPlugins:
+        frontend:
+          backstage-community.plugin-vault:
+            mountPoints:
+              - mountPoint: entity.page.overview/cards
+                importName: EntityVaultCard
+                config:
+                  layout:
+                    gridColumn: "1 / -1"
+                  if:
+                    allOf:
+                      - isVaultAvailable
+```
+
+Replace `<workspace>` and `<tag>` with the values that match your instance. See [Adding Plugins](./adding) for details on the OCI artifact format.
 
 ---
 
-### Step 2: Using the Vault Plugin
+## Prerequisites
 
-1. **Create and Manage Secrets:**
-    - Use the plugin interface to add new secrets or update existing ones.
-    - Set up access control policies to define who can view or edit secrets.
-2. **Retrieve Secrets:**
-    - Access secrets securely via the plugin's interface or API.
-    - Distribute them to applications as needed while maintaining security.
-3. **Monitor Usage:**
-    - Leverage built-in logging and monitoring features to track access events.
-    - Identify unauthorized access attempts and optimize policies as required.
+- A running HashiCorp Vault instance with the HTTP API accessible from the DevPortal backend
+- A Vault token or AppRole credentials with read access to the secret paths used by your components
 
-The Vault Plugin in DevPortal is an essential tool for modern software development, providing robust security and centralized management for sensitive data. Following these steps ensures secure storage, controlled access, and efficient distribution of secrets.
+---
 
-For further assistance, contact the VeeCode Platform support team or explore their support plans on the [website](https://platform.vee.codes/compare-plans/).
+## App configuration
 
+```yaml
+vault:
+  baseUrl: ${VAULT_BASE_URL}        # e.g. https://vault.company.com
+  token: ${VAULT_TOKEN}             # service token with read permissions
+  # secretEngine: 'kv-v2'          # default; set to 'kv-v1' if needed
+  # kvVersion: 2                    # KV secrets engine version (1 or 2)
+```
 
+---
+
+## Required annotation
+
+Add the `vault.io/secrets-path` annotation to the component's `catalog-info.yaml`:
+
+```yaml
+metadata:
+  annotations:
+    vault.io/secrets-path: secret/data/my-service
+```
+
+The entity card only renders when this annotation is present.
+
+---
+
+## References
+
+- [Backstage Community Vault plugin](https://github.com/backstage/community-plugins/tree/main/workspaces/vault)
+- [HashiCorp Vault documentation](https://developer.hashicorp.com/vault/docs)
+- [Adding Plugins to DevPortal](./adding)

--- a/devportal/rbac/creating-role.md
+++ b/devportal/rbac/creating-role.md
@@ -16,7 +16,23 @@ In a Role-Based Access Control (RBAC) system, a role is a set of permissions tha
 
 ### Default Roles in DevPortal
 
-By default, DevPortal provides the `devportal-admin` role for administrators, which grants full access. If you want to use the suggested `devportal-user` role, you can run the provided [SQL script](https://raw.githubusercontent.com/veecode-platform/support/gh-pages/references/devportal/rbac-user-default-role.sql) in your database.
+DevPortal ships three built-in roles defined in `rbac-policy.csv`:
+
+| Role | Access level |
+| --- | --- |
+| `role:default/admin` | Full access — read, create, update, delete across catalog, scaffolder, and policy management |
+| `role:default/developer` | Read/create/update access — no delete on catalog entities or tasks |
+| `role:default/viewer` | Read-only access to catalog and scaffolder templates |
+
+Default group and user assignments (also in `rbac-policy.csv`):
+- `group:default/admins` → `role:default/admin`
+- `group:default/backstage-admins` → `role:default/admin`
+- `group:default/developers` → `role:default/developer`
+- `user:default/admin` → `role:default/admin`
+
+The distro image (`veecode/devportal`) also appends `rbac-policy-extensions.csv` at build time, adding Extensions Marketplace permissions (`extensions.plugin.configuration.read/write`) to the default roles. See the [Permissions reference](./permissions.md) for the full list.
+
+RBAC is enabled by default (`permission.enabled: true` in `app-config.yaml`). To extend or override policies, mount a custom `rbac-policy.csv` or configure additional policies via the RBAC Admin UI under **Administration**.
 
 ---
 
@@ -60,3 +76,7 @@ By default, DevPortal provides the `devportal-admin` role for administrators, wh
 ![Optional Image Description](/img/rbac/6.png)
 
 By following these steps, you can efficiently create and manage roles in DevPortal, ensuring secure and structured access control. If you need further assistance, contact the DevPortal support team.
+
+:::note
+When adding a custom plugin that registers its own permissions, you must also add the plugin ID to `permission.rbac.pluginsWithPermission` in your `app-config.yaml` (or equivalent layer) for those permissions to be evaluated by the RBAC engine. The distro's `app-config.distro.yaml` pre-registers the `extensions` plugin for this purpose.
+:::

--- a/devportal/rbac/permissions.md
+++ b/devportal/rbac/permissions.md
@@ -32,7 +32,7 @@ Each permission in the RBAC system is structured as follows:
 
 | Name | Policy | Description | Requirements |
 | --- | --- | --- | --- |
-| scaffolder.action.execute | - | Allows execution of an action from a template | scaffolder.template.parameter.read, scaffolder.template.step.read |
+| scaffolder.action.execute | use | Allows execution of an action from a template | scaffolder.template.parameter.read, scaffolder.template.step.read |
 | scaffolder.template.parameter.read | read | Allows reading parameters of a template | scaffolder.template.step.read |
 | scaffolder.template.step.read | read | Allows reading steps of a template | scaffolder.template.parameter.read |
 | scaffolder.task.read | read | Allows reading scaffolder tasks | X |
@@ -56,6 +56,10 @@ Each permission in the RBAC system is structured as follows:
 ---
 
 ## **4. Platform Permissions**
+
+:::note
+These permissions are defined by optional add-on plugins (Kong, cluster explorer, API management, CI/CD, etc.). They are only enforced when the corresponding plugin is installed and enabled — they are **not** part of the default `rbac-policy.csv` shipped with the base image. Use them only if you have the relevant plugin enabled.
+:::
 
 | Name | Policy | Description | Requirements |
 | --- | --- | --- | --- |

--- a/devportal/rbac/permissions.md
+++ b/devportal/rbac/permissions.md
@@ -21,8 +21,10 @@ Each permission in the RBAC system is structured as follows:
 | --- | --- | --- | --- |
 | policy.entity.read | read | Allows the user to read permission policies/roles | X |
 | policy.entity.create | create | Allows the user to create permission policies/roles | X |
-| policy.entity.update | update | Allows the user to update permission policies/roles | X |
-| policy.entity.delete | delete | Allows the user to delete permission policies/roles | X |
+
+:::note
+`policy.entity.update` and `policy.entity.delete` are not granted in the default shipped policy. Add them to a custom role if needed.
+:::
 
 ---
 
@@ -35,7 +37,7 @@ Each permission in the RBAC system is structured as follows:
 | scaffolder.template.step.read | read | Allows reading steps of a template | scaffolder.template.parameter.read |
 | scaffolder.task.read | read | Allows reading scaffolder tasks | X |
 | scaffolder.task.create | create | Allows creating scaffolder tasks | X |
-| scaffolder.task.cancel | use | Allows canceling scaffolder tasks | X |
+| scaffolder.task.cancel | delete | Allows canceling scaffolder tasks | X |
 
 ---
 
@@ -69,3 +71,18 @@ Each permission in the RBAC system is structured as follows:
 | kong.service.manager.delete | delete | Allows removing plugins | X |
 | kong.service.manager.read | read | Allows viewing plugins | X |
 | kong.service.manager.update | update | Allows updating plugins | X |
+
+---
+
+## **5. Extensions Marketplace Permissions**
+
+These permissions are added by the distro image via `rbac-policy-extensions.csv` and control access to the plugin marketplace.
+
+| Name | Policy | Description |
+| --- | --- | --- |
+| extensions.plugin.configuration.read | read | Allows browsing the Extensions Marketplace |
+| extensions.plugin.configuration.write | create | Allows installing and uninstalling plugins via the Marketplace |
+
+By default:
+- `role:default/admin` has both `read` and `write`.
+- `role:default/developer` and `role:default/viewer` have `read` only.


### PR DESCRIPTION
Promotes the DevPortal docs accuracy overhaul from \`develop\` to production.

Bundles 14 commits across three merged develop PRs:
- **#14** — full accuracy overhaul (auth profiles, integrations, dynamic-plugin model, bundled-plugin catalog, production setup, concepts/RBAC/customization)
- **#15** — vkdr flag fix (\`--install-samples\` → \`--samples\`)
- **#16** — prose-accuracy fixes from behavioral audit (theme path, RBAC policy, OCI tags, secret handling, rollout target)

Triggers production deploy (\`docs.platform.vee.codes\`) and republish of \`@veecode/docs-mcp\` (paths match \`devportal/**\`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)