### PR TITLE
docs: comprehension refactor — composition lens across DevPortal + Platform

### DIFF
--- a/devportal/concepts/_category_.json
+++ b/devportal/concepts/_category_.json
@@ -1,4 +1,5 @@
 {
     "label": "Concepts",
-    "position": 4
+    "position": 4,
+    "link": { "type": "generated-index" }
   }

--- a/devportal/concepts/catalog.md
+++ b/devportal/concepts/catalog.md
@@ -8,6 +8,18 @@ The **Software Catalog** is the central hub of DevPortal — a registry of all s
 
 ---
 
+## Why the catalog is foundational
+
+The catalog is not an optional feature — it is the substrate that the rest of the portal binds to.
+
+- **Plugins are context-aware via annotations.** A plugin loaded in `dynamic-plugins.yaml` adds nothing visible until it finds an entity carrying the right annotation. Without entities in the catalog, plugins have no subject to attach to. (See [Composing a Portal](/platform/concepts/portal-composition) for the full three-layer model.)
+- **Templates produce catalog entries.** Every component a team creates via the scaffolder registers a `catalog-info.yaml`, which is how the portal learns the new service exists.
+- **RBAC operates on catalog entities.** Permissions are evaluated against entity ownership and relations — `spec.owner`, `spec.system`, group membership. Without the catalog populated, access control has nothing to enforce.
+
+This means Day-0 work is catalog work: register your services, APIs, and infrastructure before enabling plugins or configuring backends.
+
+---
+
 ## **Entity Kinds**
 
 The catalog tracks the following entity kinds (configured in `catalog.rules`):

--- a/devportal/concepts/configuration-hierarchy.md
+++ b/devportal/concepts/configuration-hierarchy.md
@@ -8,6 +8,11 @@ title: Configuration Hierarchy
 
 DevPortal uses a 7-layer configuration merge system. Each layer overrides values from the layers below it. Understanding this order is essential for diagnosing unexpected behavior and knowing where to put your custom settings.
 
+**Quick answer — where do I put my override?**
+- Operator customizations (branding, catalog locations, integration credentials): `app-config.local.yaml` (layer 5).
+- Auth provider and SCM integration (set once per environment): handled by `VEECODE_PROFILE` (layer 3). See [Configuration Profiles](./configuration-profiles.md).
+- Plugin-specific backend config (Kubernetes cluster URLs, Grafana domain, SonarQube base URL): also goes in `app-config.local.yaml`, or is injected via `pluginConfig` in `dynamic-plugins.yaml` (layer 6). See [Composing a Portal](/platform/concepts/portal-composition) for the relationship between plugin loading and backend config.
+
 ---
 
 ## The 7 Layers (lowest to highest priority)
@@ -120,4 +125,5 @@ If a setting is not taking effect, check:
 3. Whether the key path is correct (e.g., `app.branding.theme.light.palette.*`, not `branding.theme.light.primaryColor`).
 
 For branding-specific keys, see [Simple Branding](../customization/branding.md).  
-For profile-specific env vars, see [Configuration Profiles](./configuration-profiles.md).
+For profile-specific env vars, see [Configuration Profiles](./configuration-profiles.md).  
+For how `app-config.yaml` backend sections relate to plugin loading and entity annotations, see [Composing a Portal](/platform/concepts/portal-composition).

--- a/devportal/concepts/configuration-profiles.md
+++ b/devportal/concepts/configuration-profiles.md
@@ -32,7 +32,13 @@ A profile is not a mode or a switch — it is a YAML config file (`app-config.<p
 2. **Catalog discovery** — where to look for `catalog-info.yaml` files (GitHub org, GitLab group, etc.)
 3. **SCM integration** — credentials for the source control system so the catalog processor and scaffolder can read repositories
 
-This means that setting `VEECODE_PROFILE=github` and seeing "GitHub login works, catalog populated, templates executing in GitHub" is not magic — it is those three things being configured by a single file. To see exactly what was set, read `app-config.github.yaml` in the distro.
+This means that setting `VEECODE_PROFILE=github` and seeing "GitHub login works, catalog populated, templates executing in GitHub" is not magic — it is those three things being configured by a single file. To see exactly what was set, read the profile file directly inside the container:
+
+```bash
+docker exec devportal cat /app/app-config.github.yaml
+```
+
+Replace `github` with whatever profile you set. The file is the complete source of truth for what the profile configured.
 
 If something works that you didn't explicitly configure, it came from the profile. If you need to override any of it, add the relevant key to your `app-config.local.yaml` — it loads after the profile and wins.
 

--- a/devportal/concepts/configuration-profiles.md
+++ b/devportal/concepts/configuration-profiles.md
@@ -24,6 +24,20 @@ DevPortal ships seven **configuration profiles**, each enabling a different auth
 
 ---
 
+## What a profile configures
+
+A profile is not a mode or a switch — it is a YAML config file (`app-config.<profile>.yaml`) that gets merged into the configuration stack at startup. Each profile configures three things at once:
+
+1. **Authentication provider** — which sign-in page to show and which OAuth flow to use
+2. **Catalog discovery** — where to look for `catalog-info.yaml` files (GitHub org, GitLab group, etc.)
+3. **SCM integration** — credentials for the source control system so the catalog processor and scaffolder can read repositories
+
+This means that setting `VEECODE_PROFILE=github` and seeing "GitHub login works, catalog populated, templates executing in GitHub" is not magic — it is those three things being configured by a single file. To see exactly what was set, read `app-config.github.yaml` in the distro.
+
+If something works that you didn't explicitly configure, it came from the profile. If you need to override any of it, add the relevant key to your `app-config.local.yaml` — it loads after the profile and wins.
+
+---
+
 ## How Profiles Are Loaded
 
 At container startup, `entrypoint.sh` reads `VEECODE_PROFILE` and passes the matching config file as an extra `--config` argument to Backstage:
@@ -33,7 +47,8 @@ app-config.yaml
   → app-config.production.yaml
     → app-config.<profile>.yaml    ← loaded here
       → app-config.distro.yaml
-        → ...
+        → app-config.local.yaml    ← your overrides go here
+          → ...
 ```
 
 See [Configuration Hierarchy](./configuration-hierarchy.md) for the full 7-layer merge order.

--- a/devportal/concepts/dynamic-plugins.md
+++ b/devportal/concepts/dynamic-plugins.md
@@ -10,6 +10,18 @@ Dynamic plugins are the mechanism DevPortal uses to ship, enable, and configure 
 
 ---
 
+## Loading is step 1 of 3
+
+This doc covers how plugins are packaged and loaded. Loading is necessary but not sufficient — a loaded plugin does nothing visible until two more steps are in place:
+
+1. **Load** (`dynamic-plugins.yaml`) — this doc. Makes the plugin's code available.
+2. **Context** (entity annotations in `catalog-info.yaml`) — tells the plugin which catalog entities it should attach to. Without the correct annotation on an entity, the plugin is loaded but idle.
+3. **Backend** (`app-config.yaml`) — provides the credentials and endpoints the plugin queries. Without this, the plugin's tab appears but shows an error or empty state.
+
+All three must be in place before a developer sees live data. See [Composing a Portal](/platform/concepts/portal-composition) for the full model and a worked example.
+
+---
+
 ## Preinstalled vs. Downloaded Plugins
 
 DevPortal ships two categories of dynamic plugins:

--- a/devportal/concepts/environment-cluster-journey-veecode-platform.md
+++ b/devportal/concepts/environment-cluster-journey-veecode-platform.md
@@ -22,6 +22,8 @@ Both **Environments** and **Clusters** are modeled as `Resource` entities in the
 
 This approach creates a clear separation of concerns: the DevOps team controls environment and cluster definitions; developers consume them self-service.
 
+Because environments and clusters are catalog entities, they inherit everything the catalog provides — ownership, RBAC, search, and annotations. The same composition model that wires a `Component` to its CI plugin can wire a `Resource` (cluster) to a Grafana dashboard for cluster-level observability. See [Composing a Portal](/platform/concepts/portal-composition).
+
 **Summary:** Environments are utilized by clusters, and clusters provide the infrastructure for deploying final projects.
 
 ---

--- a/devportal/concepts/iac-template.md
+++ b/devportal/concepts/iac-template.md
@@ -81,4 +81,22 @@ You do not need to run `terraform apply`, `aws cloudformation deploy`, or any ot
 
 By adopting IaC templates, you enable your team to create and manage infrastructure efficiently through the portal, with CI/CD as the enforcement layer.
 
+---
+
+## IaC templates in the composition model
+
+An IaC template execution produces the same catalog artifacts as a software template: a repository, a `catalog-info.yaml`, and a registered `Location` entity — except the entity kind is `Resource` rather than `Component`. That resource entity appears in the catalog, carries ownership metadata, and can have annotations that attach it to observability plugins (Grafana dashboards scoped to the provisioned infrastructure, for example).
+
+The resource entity is the catalog's representation of the infrastructure. It is queryable via the Relations API, visible on dependency graphs, and subject to the same RBAC rules as any other entity.
+
+### Template-of-templates: app + infra as a single Golden Path
+
+An IaC template can be a step inside a software template. The software template orchestrates both: it scaffolds the application repository and invokes the IaC template (or an equivalent scaffolder action) to provision the required infrastructure in the same workflow. The developer fills in one form; both a `Component` entity and a `Resource` entity emerge, linked via the `dependsOn` relation in `catalog-info.yaml`.
+
+This is the mechanism behind a complete [Golden Path](/platform/concepts/golden-paths): the template encodes the organization's standard for what a production-ready service looks like — application code, CI/CD configuration, and infrastructure — as a single self-service operation.
+
+For the three-layer model that governs how the resulting entities connect to plugins, see [Composing a Portal](/platform/concepts/portal-composition). For the software template side of this pattern, see [Software Templates](/devportal/concepts/software-template).
+
+---
+
 For further assistance, refer to your platform's documentation or [contact us](https://platform.vee.codes/support/).

--- a/devportal/concepts/software-template.md
+++ b/devportal/concepts/software-template.md
@@ -94,6 +94,50 @@ Templates are the primary mechanism through which [Golden Paths](/platform/conce
 - **Compliance by default:** Security and governance requirements are built into the template rather than enforced after the fact.
 - **Scalability:** Adding a new team or project type means adding a template, not duplicating runbooks.
 
+---
+
+## What template execution actually produces
+
+Running a template creates more than a project skeleton. The scaffolder executes a sequence of steps that leaves a durable trail in the catalog:
+
+1. **A new repository in the configured SCM** — the target provider (GitHub, GitLab, etc.) and organization are set by the configuration profile loaded at startup. The scaffolder uses those credentials; the developer doesn't configure SCM access per template.
+
+2. **A `catalog-info.yaml` committed to that repository** — this is the entity descriptor. It declares the component kind, owner, system, and — critically — the annotations that bind the entity to plugins.
+
+3. **A Location entity registered in the catalog** — the scaffolder registers a `Location` pointing at the new `catalog-info.yaml`. From that moment the new component appears in the portal catalog without any manual registration step.
+
+4. **An entity wired for plugins, RBAC, and TechDocs** — the component is visible immediately, and the tabs and cards that appear on it are determined by what annotations the template wrote into `catalog-info.yaml`.
+
+The last point is the key design decision for template authors. A template that emits no annotations produces a catalog entry with no plugin tabs. A template that emits the right annotations produces a component that already has its CI tab, Kubernetes tab, and Grafana cards populated — before the developer pushes a single commit.
+
+### The annotation decision happens at template authoring time
+
+When a developer runs a template, they don't see annotation fields. Those are fixed by the template. The platform team decides which annotations to include when they write the template, and every component created from that template inherits the same plugin surface.
+
+Example: a template for a Node.js API service might emit:
+
+```yaml
+metadata:
+  annotations:
+    backstage.io/kubernetes-label-selector: 'app={{ values.componentId }}'
+    gitlab.com/project-slug: '{{ values.group }}/{{ values.componentId }}'
+    backstage.io/techdocs-ref: dir:.
+```
+
+Every component created from that template will have a Kubernetes tab, a GitLab CI tab, and TechDocs — provided those plugins are loaded and the backends are configured. The developer gets those surfaces automatically; the platform team controls what "automatically" means.
+
+For the full picture of how load, context, and backend interact, see [Composing a Portal](/platform/concepts/portal-composition).
+
+---
+
+## References
+
+- [Composing a Portal](/platform/concepts/portal-composition) — how plugins attach to entities via the three-layer model
+- [The Catalog](/devportal/concepts/catalog) — entity kinds, ownership, and how `catalog-info.yaml` is processed
+- [Golden Paths](/platform/concepts/golden-paths) — the platform strategy that templates implement
+
+---
+
 If additional help is needed, contact the support team or watch the video.
 <center>
 <iframe src="https://www.youtube.com/embed/2KX8fFaoIAk" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>

--- a/devportal/concepts/software-template.md
+++ b/devportal/concepts/software-template.md
@@ -85,14 +85,14 @@ Upon completion:
 
 ---
 
-## Benefits of Using Templates
+## Why Templates Matter
 
-- **Efficiency:** Predefined configurations save time.
-- **Standardization:** Ensures consistency across projects.
-- **Scalability:** Easily replicable infrastructure for new components.
-- **Integration:** Simplifies linking to CI/CD and database systems.
+Templates are the primary mechanism through which [Golden Paths](/platform/concepts/golden-paths) are delivered in the DevPortal. Rather than a developer searching for the "right" way to start a new service, a well-crafted template makes the right way the easiest way.
 
-You now have a comprehensive understanding of the **template creation feature** in the Developer Portal. By using this tool, you can streamline project setup and focus on development tasks.
+- **Self-service:** Teams spin up new services without opening a ticket to the platform team.
+- **Standardization:** Every project starts from the same base — same Dockerfile structure, same CI pipeline, same observability hooks.
+- **Compliance by default:** Security and governance requirements are built into the template rather than enforced after the fact.
+- **Scalability:** Adding a new team or project type means adding a template, not duplicating runbooks.
 
 If additional help is needed, contact the support team or watch the video.
 <center>

--- a/devportal/installation-guide/installation-guide.md
+++ b/devportal/installation-guide/installation-guide.md
@@ -11,35 +11,20 @@ You can use VeeCode DevPortal for free in many possible ways. Find here a few se
 :::
 
 import style from '../style.module.css';
+import DocCard from '@site/src/components/DocCard';
 
 <div className={style.wrapper}>
 
-export const Card = ({children, title, link}) => (
-   <div className={style.card}
-      onClick={() => window.location = link }
-      onKeyDown={(e) => e.key === 'Enter' && (window.location = link)}
-      tabIndex={0}
-      role="button"
-      aria-label={`Navigate to ${title}`}>
-      <div className={style.titlebar}>
-         <h3 className={style.title}>{title}</h3>
-      </div>
-      <p className={style.desc}>
-         {children}
-      </p>
-   </div>
-);
+<DocCard title="Docker Run (Quickstart)" link="./docker-local/intro" style={style}>Quickly run DevPortal locally using Docker. Ideal for testing and exploration without Kubernetes.</DocCard>
 
-<Card title="Docker Run (Quickstart)" link="./docker-local/intro">Quickly run DevPortal locally using Docker. Ideal for testing and exploration without Kubernetes.</Card>
+<DocCard title="VKDR (Local Kubernetes)" link="./vkdr-local/vkdr-setup" style={style}>Install DevPortal locally on a lightweight Kubernetes cluster using VKDR. Best for reproducing production scenarios.</DocCard>
 
-<Card title="VKDR (Local Kubernetes)" link="./vkdr-local/vkdr-setup">Install DevPortal locally on a lightweight Kubernetes cluster using VKDR. Best for reproducing production scenarios.</Card>
+<DocCard title="Simple Setup" link="./simple-setup" style={style}>Learn how to install a self-hosted Developer Portal with a simple setup (trial, demo or small production environment).</DocCard>
 
-<Card title="Simple Setup" link="./simple-setup">Learn how to install a self-hosted Developer Portal with a simple setup (trial, demo or small production environment).</Card>
+<DocCard title="Production Setup" link="./production-setup" style={style}>Learn how to install a self-hosted and production-ready Developer Portal on your own infrastructure.</DocCard>
 
-<Card title="Production Setup" link="./production-setup">Learn how to install a self-hosted and production-ready Developer Portal on your own infrastructure.</Card>
+<DocCard title="Customization" link="/devportal/customization" style={style}>Learn how to customize your Developer Portal.</DocCard>
 
-<Card title="Customization" link="/devportal/customization">Learn how to customize your Developer Portal.</Card>
-
-<Card title="FAQs" link="./FAQs">Frequently Asked Questions.</Card>
+<DocCard title="FAQs" link="./FAQs" style={style}>Frequently Asked Questions.</DocCard>
 
 </div>

--- a/devportal/installation-guide/simple-setup/check-prerequisites.md
+++ b/devportal/installation-guide/simple-setup/check-prerequisites.md
@@ -6,12 +6,10 @@ title: Check prerequisites and accounts
 
 Use this checklist to ensure you're ready to install the DevPortal.
 
-- Kubernetes cluster available and reachable (kubeconfig set)
-- `kubectl` and `helm` installed locally
-- DNS/host chosen for the DevPortal (e.g., devportal.yourdomain.com)
-- Git provider account ready (GitHub or GitLab)
-- Optional: Ingress controller (nginx or kong) installed in the cluster
+- [ ] Kubernetes cluster available and reachable (kubeconfig set)
+- [ ] `kubectl` and `helm` installed locally
+- [ ] DNS/host chosen for the DevPortal (e.g., devportal.yourdomain.com)
+- [ ] Git provider account ready (GitHub or GitLab)
+- [ ] Optional: Ingress controller (nginx or kong) installed in the cluster
 
-We will detail those steps below, but if you already have them ready, you can skip to the next section named [Create or choose a target organization/group](./target-organization-group).
-
-TODO: Add a checklist to verify if you have all the prerequisites ready.
+If you already have them ready, you can skip to the next section named [Create or choose a target organization/group](./target-organization-group).

--- a/devportal/installation-guide/simple-setup/choose-template-catalog.md
+++ b/devportal/installation-guide/simple-setup/choose-template-catalog.md
@@ -18,4 +18,3 @@ We recommend that you start by forking (or just copying) our [public base catalo
 You may simply point directly to the public base catalog repository if you don't plan to make any changes to it, but forking/copying is recommended for better security and control (you should work with your own template catalog).
 :::
 
-TODO: video showing the fork process in GitHub UI.

--- a/devportal/intro.md
+++ b/devportal/intro.md
@@ -9,11 +9,7 @@ import DocCard from '@site/src/components/DocCard';
 
 # Intro
 
-:::tip
-This documentation is being updated to our latest release supporting dynamic plugins. Keep in touch and, by all means, file PRs to help us improve it.
-:::
-
-Welcome to VeeCode Developer Portal documentation! This document will guide you through our Developer Portal, which is a modern and open-source Platform Engineering solution designed to help organizations better manage their API and service ecosystems.
+Welcome to VeeCode Developer Portal documentation. This guide covers installation, plugins, and concepts for running DevPortal on your infrastructure.
 
 ### What is VeeCode DevPortal?
 
@@ -28,7 +24,7 @@ VeeCode DevPortal is a Backstage distro that provides a production-grade portal 
 - It is an API showcase and governance tool for both developers and business partners
 - It simplifies DevOps adoption and scaling, removing cognitive load from average teams
 
-This documentation guide aims to help you understand the workings of the Developer Portal, how to use it, and how to customize it to meet your specific needs. Here are some of the topics covered in this guide:
+If you want to understand **why** this portal matters before diving into setup — the reasoning behind golden paths, self-service design, and developer autonomy — start with [Platform Concepts](/platform/concepts). If you're here to install and configure, continue below.
 
 <div className={style.wrapper}>
 
@@ -36,7 +32,7 @@ This documentation guide aims to help you understand the workings of the Develop
 
 <DocCard title="💡 Concepts" link="/devportal/concepts/catalog" style={style}>Understand the core concepts and terminology related to the Developer Portal.</DocCard>
 
-<DocCard title="🧩 Plugins" link="/devportal/plugins/techdocs" style={style}>Customize and extend the functionality of your Developer Portal.</DocCard>
+<DocCard title="🧩 Plugins" link="/devportal/plugins/plugins" style={style}>Enable and configure plugins to extend DevPortal with Day-2 capabilities.</DocCard>
 
 <DocCard title="📍 Troubleshooting" link="/devportal/troubleshooting" style={style}>Find solutions to common issues and learn how to report errors.</DocCard>
 

--- a/devportal/intro.md
+++ b/devportal/intro.md
@@ -5,6 +5,7 @@ title: Intro to DevPortal
 ---
 
 import style from './style.module.css';
+import DocCard from '@site/src/components/DocCard';
 
 # Intro
 
@@ -31,33 +32,13 @@ This documentation guide aims to help you understand the workings of the Develop
 
 <div className={style.wrapper}>
 
-export const Card = ({children, title, link}) => (
-   <div className={style.card}
-      onClick={() => window.location = link }
-      onKeyDown={(e) => e.key === 'Enter' && (window.location = link)}
-      tabIndex={0}
-      role="button"
-      aria-label={`Navigate to ${title}`}>
-      <div className={style.titlebar}>
-         <h3 className={style.title}>{title}</h3>
-      </div>
-      <p className={style.desc}>
-         {children}
-      </p>
-   </div>
-);
+<DocCard title="💻 Installation Guide" link="/devportal/installation-guide/simple-setup" style={style}>Learn how to install the Developer Portal on your own infrastructure.</DocCard>
 
-<!-- <Card title="📄️ Self-Service Demo" link="self-service-demo/prerequisites">Explore the platform's features through a simple interactive demo.</Card> -->
+<DocCard title="💡 Concepts" link="/devportal/concepts/catalog" style={style}>Understand the core concepts and terminology related to the Developer Portal.</DocCard>
 
-<Card title="💻 Installation Guide" link="/devportal/installation-guide/simple-setup">Learn how to install the Developer Portal on your own infrastructure.</Card>
+<DocCard title="🧩 Plugins" link="/devportal/plugins/techdocs" style={style}>Customize and extend the functionality of your Developer Portal.</DocCard>
 
-<Card title="💡 Concepts" link="/devportal/concepts/catalog">Understand the core concepts and terminology related to the Developer Portal.</Card>
-
-<!-- <Card title="🌐 API Management" link="/devportal/api-management/apiManagement">Effectively manage your APIs and services using the Developer Portal.</Card> -->
-
-<Card title="🧩 Plugins" link="/devportal/plugins/techdocs">Customize and extend the functionality of your Developer Portal.</Card>
-
-<Card title="📍 Troubleshooting" link="/devportal/troubleshooting">Find solutions to common issues and learn how to report errors.</Card>
+<DocCard title="📍 Troubleshooting" link="/devportal/troubleshooting" style={style}>Find solutions to common issues and learn how to report errors.</DocCard>
 
 </div>
 

--- a/devportal/observability/_category_.json
+++ b/devportal/observability/_category_.json
@@ -1,4 +1,5 @@
 {
     "label": "Observability",
-    "position": 7
+    "position": 7,
+    "link": { "type": "generated-index" }
   }

--- a/devportal/plugins/GitHubWorkflows.md
+++ b/devportal/plugins/GitHubWorkflows.md
@@ -6,7 +6,9 @@ title: GitHub Workflows Plugin
 
 # GitHub Workflows Plugin
 
-The GitHub Workflows plugin provides an alternative for manually triggering GitHub workflows from within your DevPortal component. It offers two distinct approaches:
+Without this plugin, triggering a workflow means leaving the portal, navigating to GitHub, finding the repository, and running the action from there — the developer loses service context and the portal has no visibility into what happened. Enable the plugin, add `github.com/project-slug` to the entity, and a workflow card appears on the entity overview. Workflows can be triggered and monitored without leaving the service page.
+
+The GitHub Workflows plugin provides manual workflow triggering from within a DevPortal component. It offers two distinct approaches:
 
 - **Workflows List** — lists all workflows in the repository, with branch selection and manual trigger support.
 - **Workflow Cards** — an overview card showing only workflows pinned via annotation.

--- a/devportal/plugins/GitLabPipelines.md
+++ b/devportal/plugins/GitLabPipelines.md
@@ -6,6 +6,8 @@ title: GitLab Pipelines Plugin
 
 # GitLab Pipelines Plugin
 
+Without this plugin, a service registered in the portal has no visibility into its own CI pipelines. Developers context-switch to GitLab to check pipeline status or trigger runs — the portal and the CI tool are disconnected. Enable the plugin, add `gitlab.com/project-slug` to the entity, and the CI tab shows live pipeline history with the ability to trigger new runs directly from the portal.
+
 The GitLab Pipelines plugin integrates GitLab CI with your DevPortal component. It provides two views:
 
 - **Pipelines List** — lists recent pipelines with the ability to trigger or cancel runs.

--- a/devportal/plugins/Sonar.md
+++ b/devportal/plugins/Sonar.md
@@ -6,7 +6,9 @@ title: SonarQube
 
 # SonarQube Plugin
 
-The SonarQube plugin for DevPortal displays code quality metrics — bugs, vulnerabilities, test coverage, and duplications — directly in the component catalog. It connects to your SonarQube instance and surfaces key insights inside Backstage.
+Without this plugin, code quality is a concern that lives separately in SonarQube — a dashboard the team checks independently, disconnected from the service entity. Enable the plugin, add `sonarqube.org/project-key` with the project key from your SonarQube instance, and a Code Quality tab appears on the entity showing bugs, vulnerabilities, coverage, and technical debt for that specific service. Quality is now part of the service's record, not an external afterthought.
+
+The SonarQube plugin displays code quality metrics — bugs, vulnerabilities, test coverage, and duplications — directly in the component catalog.
 
 ---
 

--- a/devportal/plugins/adding.md
+++ b/devportal/plugins/adding.md
@@ -6,6 +6,10 @@ title: Adding Plugins
 
 You can add dynamic plugins to your DevPortal instance at any time without rebuilding the base image.
 
+:::note
+Adding a plugin is the **load** step — step 1 of 3 in the plugin activation model. A loaded plugin does nothing visible until the relevant catalog entities carry the correct annotation (context) and `app-config.yaml` configures the backend it queries. See [Composing a Portal](/platform/concepts/portal-composition) for the full model.
+:::
+
 ## Prerequisites
 
 - A running DevPortal instance

--- a/devportal/plugins/bundled/azure-devops.md
+++ b/devportal/plugins/bundled/azure-devops.md
@@ -6,6 +6,8 @@ title: Azure DevOps Plugin
 
 # Azure DevOps Plugin
 
+Without this plugin, Azure Pipelines builds and Pull Requests are tracked only in Azure DevOps — a service registered in the portal has no operational visibility from it. Enable the plugin, add `dev.azure.com/project-repo` to the entity, and the entity gains both a CI tab (Pipelines build history) and a Pull Requests tab. The portal becomes the entry point for CI and code review workflows, not Azure DevOps.
+
 The Azure DevOps plugin displays Azure Pipelines builds and Azure Pull Requests in catalog entity pages.
 
 **Status:** Preloaded in the DevPortal image, **disabled by default**. Enable via `dynamic-plugins.yaml` or Marketplace.

--- a/devportal/plugins/bundled/github-actions.md
+++ b/devportal/plugins/bundled/github-actions.md
@@ -6,6 +6,8 @@ title: GitHub Actions Plugin
 
 # GitHub Actions Plugin
 
+Without this plugin, CI history lives only in GitHub — the developer has to leave the portal to check whether a build passed or trace a failed run back to a commit. Enable the plugin, add `github.com/project-slug` to the entity, and a CI tab appears showing recent Actions run history with status, duration, and direct links to logs. Build health becomes part of the service's entity, not a separate GitHub tab.
+
 The GitHub Actions plugin displays GitHub Actions workflow run history in the CI tab of catalog entities. It is the standard Backstage community plugin for GitHub Actions integration.
 
 **Status:** Preloaded in the DevPortal image, **disabled by default**. Enable via `dynamic-plugins.yaml` or Marketplace.

--- a/devportal/plugins/bundled/index.md
+++ b/devportal/plugins/bundled/index.md
@@ -10,6 +10,8 @@ DevPortal ships with a set of **preinstalled dynamic plugins** baked into the di
 
 A few core plugins (`preInstalled: true` in `dynamic-plugins.default.yaml`) are always loaded — they power the UI shell, navigation, and marketplace itself.
 
+Think of this catalog in terms of capability layers, not a flat install list. The always-on plugins establish the shell. The disabled-by-default plugins represent operational capabilities — CI/CD visibility, infrastructure observability, code quality — that your team activates based on what context-switches it wants to eliminate. Each plugin connects to a service entity via an annotation; the right question before enabling any plugin is "which entities will carry this annotation, and what does it replace for their developers?" See [Composing a Portal](/platform/concepts/portal-composition) for the full three-layer model.
+
 ---
 
 ## Always-on plugins (preInstalled, no YAML entry needed)

--- a/devportal/plugins/bundled/jenkins.md
+++ b/devportal/plugins/bundled/jenkins.md
@@ -6,6 +6,8 @@ title: Jenkins Plugin
 
 # Jenkins Plugin
 
+Without this plugin, build status lives in Jenkins — developers context-switch to check whether a build passed, find the right job among many, and trace failures back to code. Enable the plugin, add `jenkins.io/job-full-name` with the job path in Jenkins, and a CI tab appears on the entity showing build history and status. Configure `JENKINS_URL` and credentials in the backend plugin config.
+
 The Jenkins plugin displays Jenkins build status in catalog entity pages.
 
 **Status:** Preloaded in the DevPortal image, **disabled by default**. Enable via `dynamic-plugins.yaml` or Marketplace.

--- a/devportal/plugins/cicd.md
+++ b/devportal/plugins/cicd.md
@@ -6,6 +6,10 @@ title: CI/CD Plugins
 
 # CI/CD Plugins
 
+The problem CI/CD plugins solve is the same across every platform: the service is registered in the portal, but its pipeline lives in GitHub Actions, GitLab, Jenkins, or Azure DevOps. Developers context-switch to check builds, find failures, and trigger runs. Each CI/CD plugin closes that gap for one platform by surfacing build status and triggers on the entity page itself — the service and its pipeline become one view.
+
+This is the [Application Lifecycle](/platform/capabilities) capability layer in practice. Pick the plugin that matches the platform your team uses; the activation pattern is the same for all of them.
+
 DevPortal ships several separate CI/CD plugins, each integrating with a specific CI/CD platform. There is no single "CI/CD Plugin" — each platform has its own bundled plugin that must be enabled individually.
 
 All CI/CD plugins described here are **preloaded in the DevPortal image and disabled by default**. Enable them via `dynamic-plugins.yaml` or the Marketplace — no support contact required.

--- a/devportal/plugins/grafana.md
+++ b/devportal/plugins/grafana.md
@@ -6,7 +6,9 @@ title: Grafana Plugin
 
 # Grafana Plugin
 
-The Grafana plugin for Backstage embeds Grafana dashboards and alert panels in entity pages, giving developers direct observability access from the catalog.
+Without this plugin, Grafana dashboards are a separate tab the developer has to remember to open — and without the service entity as context, they're dashboards, not "the dashboard for this service." Enable the plugin, add `grafana/dashboard-selector` to the entity with a tag expression matching that service's dashboards, and an observability card appears in the entity overview. Metrics are now anchored to the service, not floating in a separate tool.
+
+The Grafana plugin embeds Grafana dashboards and alert panels in entity pages, giving developers direct observability access from the catalog.
 
 :::note
 The Grafana plugin is **not bundled** in the DevPortal image. It must be added as an external dynamic plugin via `dynamic-plugins.yaml` or the Marketplace. No support plan is required — the plugin is a standard Backstage community plugin available publicly.

--- a/devportal/plugins/kubernetes.md
+++ b/devportal/plugins/kubernetes.md
@@ -6,7 +6,11 @@ title: Kubernetes Plugin
 
 # Kubernetes Plugin
 
-The Kubernetes plugin for Backstage displays the live state of Kubernetes resources — pods, deployments, services, and more — for a catalog entity. It appears as a **Kubernetes tab on the entity page** (not a sidebar item).
+Without this plugin, a service created through DevPortal has no connection to its own Kubernetes workloads — the developer still needs to context-switch to `kubectl` or a separate dashboard to check pod status, restart counts, or logs. The portal becomes a creation tool but not an operational one.
+
+With the plugin enabled, the entity page becomes the operational view for the service: pods, deployment rollout status, and live logs visible in the same place the team already uses to understand the service.
+
+The Kubernetes plugin displays the live state of Kubernetes resources — pods, deployments, services, and more — for a catalog entity. It appears as a **Kubernetes tab on the entity page** (not a sidebar item).
 
 The plugin is **preloaded in the DevPortal image** and disabled by default. No image rebuild or support contact is needed to enable it.
 

--- a/devportal/plugins/plugins.md
+++ b/devportal/plugins/plugins.md
@@ -8,6 +8,8 @@ Plugins are how the portal becomes useful beyond Day-0 setup. The base DevPortal
 
 VeeCode DevPortal is built on top of [Backstage](https://backstage.io/) and ships with a set of bundled plugins ready to enable. Understand what each plugin adds before enabling it — the value is in the workflow it removes, not in the YAML you write.
 
+Before choosing which plugins to enable, read [Composing a Portal](/platform/concepts/portal-composition) — it explains the three-layer activation model (load → annotation → backend) and maps plugin combinations to operational use cases.
+
 ## Plugin Types
 
 Backstage’s extensibility model is built around plugins that can contribute functionality either to the backend, the frontend, or as modules that extend other plugins or backend components (such as the scaffolder). VeeCode DevPortal extends this model to support dynamic plugins with reasonable defaults.

--- a/devportal/plugins/plugins.md
+++ b/devportal/plugins/plugins.md
@@ -4,7 +4,9 @@ sidebar_label: Plugins
 title: Backstage Plugins
 ---
 
-VeeCode DevPortal is built on top of [Backstage](https://backstage.io/), an open platform for building developer portals. Backstage offers a rich ecosystem of plugins that can be integrated into DevPortal to extend its functionality and tailor it to your organization's needs.
+Plugins are how the portal becomes useful beyond Day-0 setup. The base DevPortal gives you a service catalog and a template runner — plugins are what turn it into a central hub where teams actually operate their services: checking deployments, tracking pipelines, monitoring code quality, without leaving the portal.
+
+VeeCode DevPortal is built on top of [Backstage](https://backstage.io/) and ships with a set of bundled plugins ready to enable. Understand what each plugin adds before enabling it — the value is in the workflow it removes, not in the YAML you write.
 
 ## Plugin Types
 

--- a/devportal/plugins/techdocs.md
+++ b/devportal/plugins/techdocs.md
@@ -6,6 +6,8 @@ title: Tech Docs
 
 # TechDocs
 
+TechDocs is preinstalled and active — it doesn't need to be enabled. The question is whether your services are using it. Without the `backstage.io/techdocs-ref` annotation and a `mkdocs.yml` in the repository, the Docs tab is absent from the entity. With both in place, documentation for the service is browsable inside the portal, versioned with the code, and always in sync with the current state of the service — not in a separate Confluence space that drifts.
+
 TechDocs is a **docs-as-code** system built into Backstage. Documentation lives as Markdown files in your source repository and is rendered inside DevPortal. There is no in-portal editor, "New Page" button, or "Publish" button — content is written, committed, and built from the repository.
 
 ---

--- a/devportal/plugins/vault.md
+++ b/devportal/plugins/vault.md
@@ -6,7 +6,9 @@ title: Vault Plugin
 
 # Vault Plugin
 
-The Vault plugin for Backstage displays HashiCorp Vault secrets associated with a catalog entity, allowing developers to view secret paths and metadata directly from the DevPortal UI.
+Without this plugin, secrets are completely opaque from the portal's perspective. A developer who wants to know what secrets a service depends on must navigate to Vault separately, with separate credentials, and know where to look. Enable the plugin, add `vault.io/secrets-path` with the secret path prefix for that service, and the entity overview shows the secret paths — so the team knows what the service depends on without switching tools. The plugin shows paths and metadata only, not secret values.
+
+The Vault plugin displays HashiCorp Vault secrets associated with a catalog entity, allowing developers to view secret paths and metadata directly from the DevPortal UI.
 
 :::note
 The Vault plugin is **not bundled** in the DevPortal image. It must be added as an external dynamic plugin via `dynamic-plugins.yaml` or the Marketplace. No special support plan is required — the plugin is a standard Backstage community plugin available publicly.

--- a/devportal/rbac/_category_.json
+++ b/devportal/rbac/_category_.json
@@ -1,4 +1,5 @@
 {
     "label": "RBAC",
-    "position": 9
+    "position": 9,
+    "link": { "type": "generated-index" }
   }

--- a/platform/capabilities/_category_.json
+++ b/platform/capabilities/_category_.json
@@ -1,4 +1,5 @@
 {
     "label": "Capabilities",
-    "position": 4
+    "position": 4,
+    "link": { "type": "generated-index" }
 }

--- a/platform/capabilities/platform-capabilities.md
+++ b/platform/capabilities/platform-capabilities.md
@@ -6,28 +6,69 @@ title: Platform Capabilities
 
 # Platform Capabilities
 
-An Internal Developer Platform typically provides a cohesive set of capabilities that streamline the end-to-end software delivery lifecycle, abstract infrastructure complexity, and improve operational reliability.
+An Internal Developer Platform delivers value across four capability layers. The layers are interdependent — an observability layer without a service catalog to anchor dashboards to is just a dashboard tool. Composition is what makes the platform more than the sum of its parts.
+
+For a concrete walkthrough of how these layers come together in a running portal, see [Composing a Portal](/platform/concepts/portal-composition).
+
+---
 
 ## Developer Experience Layer
-- **Self-service portals**: Web interfaces for common tasks
-- **CLI tools**: Command-line interfaces for power users
-- **IDE integrations**: Plugins and extensions for popular development environments
-- **Documentation**: Comprehensive guides, tutorials, and API references
 
-## Application Lifecycle Management
-- **Source code management**: Git-based workflows with branch protection
-- **Build and test automation**: Standardized CI/CD pipelines
-- **Artifact management**: Container registries and package repositories
-- **Deployment automation**: Infrastructure provisioning and application deployment
+**The problem it solves:** Developers spend time on undifferentiated work — figuring out how to start a new project, how to structure CI, where to find documentation for a dependency. Each team invents its own answer.
 
-## Infrastructure Abstraction
-- **Compute resources**: Standardized runtime environments
-- **Storage solutions**: Persistent volumes and object storage
-- **Networking**: Service discovery, load balancing, and ingress management
-- **Security**: Identity management, secrets handling, and policy enforcement
+**How DevPortal realizes it:**
+- **Service catalog** — a single place to discover every service, API, and resource in the organization, with its ownership, lifecycle, and documentation
+- **Software templates** — opinionated project bootstraps that encode the organization's [Golden Paths](/platform/concepts/golden-paths) so the right way is also the easiest way
+- **TechDocs** — documentation lives in the service repository and renders inside the portal, versioned with the code and always in context
 
-## Observability and Operations
-- **Monitoring**: Application and infrastructure metrics
-- **Logging**: Centralized log aggregation and search
-- **Tracing**: Distributed request tracing
-- **Alerting**: Intelligent notification systems
+The catalog is the foundation everything else builds on. Without a populated catalog, plugins have no entities to attach to.
+
+---
+
+## Application Lifecycle Layer
+
+**The problem it solves:** Developers context-switch between the portal (which knows about the service) and CI/CD tools (which know about its builds). The service and its pipeline are the same thing, but they live in different places.
+
+**How DevPortal realizes it** (via plugins):
+- **[GitHub Actions](/devportal/plugins/bundled/github-actions)** — CI run history on the entity page
+- **[GitHub Workflows](/devportal/plugins/GitHubWorkflows)** — manual workflow triggers from the entity overview
+- **[GitLab Pipelines](/devportal/plugins/GitLabPipelines)** — pipeline list and job triggers for GitLab CI
+- **[Jenkins](/devportal/plugins/bundled/jenkins)** — build status for Jenkins pipelines
+- **[Azure DevOps](/devportal/plugins/bundled/azure-devops)** — Azure Pipelines and Pull Requests on entity pages
+
+Each plugin connects to the entity via an annotation in `catalog-info.yaml`. The entity declares which project it maps to in the CI tool; the plugin reads that and surfaces the relevant data.
+
+---
+
+## Infrastructure Abstraction Layer
+
+**The problem it solves:** Infrastructure is opaque to application developers. They don't know what Kubernetes cluster their service runs on, what secrets it uses, or what version is deployed. That knowledge lives with the platform team or in separate tools.
+
+**How DevPortal realizes it** (via plugins):
+- **[Kubernetes](/devportal/plugins/kubernetes)** — live pod status, deployment rollout, and logs for the service's workloads
+- **[Vault](/devportal/plugins/vault)** — secrets metadata visible on the entity page (paths and keys, not values)
+- **IaC templates** — infrastructure provisioned through the portal's scaffolder, so infrastructure creation follows the same Golden Path as application creation
+
+The Kubernetes plugin is the most direct bridge: a service entity with the right label selector annotation shows exactly which pods belong to it and their current health.
+
+---
+
+## Observability Layer
+
+**The problem it solves:** Metrics, logs, and alerts live in separate tools. A developer responding to an incident has to pivot between the portal (to understand the service), Grafana (to see metrics), and potentially a code quality tool to understand technical debt.
+
+**How DevPortal realizes it** (via plugins):
+- **[Grafana](/devportal/plugins/grafana)** — dashboards scoped to the entity, embedded in the overview
+- **[SonarQube](/devportal/plugins/Sonar)** — code quality metrics (bugs, coverage, vulnerabilities) on the entity's Code Quality tab
+
+The `grafana/dashboard-selector` annotation connects the entity to its dashboards by tag. The `sonarqube.org/project-key` annotation connects it to its SonarQube project. Each connection is explicit and per-entity — one service's dashboards don't bleed into another's.
+
+---
+
+## How the layers compose
+
+A portal with only the Developer Experience layer is useful for onboarding and discovery. Add the Application Lifecycle layer and developers can trigger deployments from the same page where they read service documentation. Add Infrastructure Abstraction and they can see pod health without a kubectl context. Add Observability and they can correlate a deployment with a metrics spike — all within the service entity.
+
+The question for every plugin evaluation: **which context-switch does this eliminate, and for which team?**
+
+See [Composing a Portal](/platform/concepts/portal-composition) for a step-by-step example.

--- a/platform/concepts/_category_.json
+++ b/platform/concepts/_category_.json
@@ -1,4 +1,5 @@
 {
     "label": "Concepts",
-    "position": 2
+    "position": 2,
+    "link": { "type": "generated-index" }
   }

--- a/platform/concepts/golden-paths.md
+++ b/platform/concepts/golden-paths.md
@@ -21,7 +21,7 @@ In a complex cloud-native environment, developers often face a paradox of choice
 
 ## Examples
 
-A Golden Path is typically realized through a **Software Template** in the DevPortal.
+A Golden Path is typically realized through a **[Software Template](/devportal/concepts/software-template)** in the DevPortal.
 
 ### 1. Spring Boot on Kubernetes
 For backend services, a Golden Path might include:

--- a/platform/concepts/portal-composition.md
+++ b/platform/concepts/portal-composition.md
@@ -1,0 +1,187 @@
+---
+sidebar_position: 3
+sidebar_label: Composing a Portal
+title: Composing a Portal
+---
+
+# Composing a Portal
+
+A DevPortal installation out of the box is a service catalog and a template runner. Teams can register their services, create new ones from templates, and browse the software landscape. That is Day-0: the portal knows what exists and can create things, but it doesn't connect to anything live yet.
+
+The value engineers actually care about — seeing pod status, triggering a deployment, checking code quality, browsing Grafana dashboards without leaving the service page — comes from plugin composition. Understanding how composition works is what separates "I ran the YAML" from "I built an operational hub."
+
+---
+
+## Three levels of composition
+
+Every plugin activates across three layers. All three must be in place before a developer sees anything.
+
+### 1. Load — `dynamic-plugins.yaml`
+
+This controls which plugins are present at all. Flip `disabled: false` for a bundled plugin, or add an OCI reference for an external one. No image rebuild required.
+
+```yaml
+plugins:
+  - package: ./dynamic-plugins/dist/backstage-plugin-kubernetes-dynamic
+    disabled: false
+```
+
+Enabling a plugin here loads its code. UI components are available. But nothing appears to the developer yet.
+
+### 2. Context — entity annotations
+
+Plugins are **context-aware by design**. They do not add global tabs. They add tabs and cards to specific catalog entities — and only when those entities carry the right annotation.
+
+```yaml
+# catalog-info.yaml
+metadata:
+  annotations:
+    backstage.io/kubernetes-label-selector: 'app=my-service'
+```
+
+Without this annotation on the entity, the Kubernetes plugin is loaded but idle. With it, the Kubernetes tab appears on that entity only, and shows pods matching the selector.
+
+This is intentional. A platform with dozens of services doesn't need every plugin visible on every entity. Each service declares what it uses. The portal surfaces exactly what belongs to that service.
+
+### 3. Backend — `app-config.yaml`
+
+The tab appears. But it needs to know where to fetch data from. The backend configuration provides that:
+
+```yaml
+kubernetes:
+  clusterLocatorMethods:
+    - type: config
+      clusters:
+        - name: production
+          url: ${K8S_CLUSTER_URL}
+          serviceAccountToken: ${K8S_CLUSTER_TOKEN}
+```
+
+Without this, the tab loads and shows an error or empty state. With all three layers in place, the tab displays live data.
+
+### The diagnostic model
+
+A plugin that fails silently has failed at one of these three levels:
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| Tab not visible on entity | Annotation missing | Add annotation to `catalog-info.yaml` |
+| Tab visible, empty or error | Backend not configured | Check `app-config.yaml` for the relevant integration |
+| Nothing plugin-related works | Plugin not loaded | Check `disabled: false` in `dynamic-plugins.yaml` |
+
+---
+
+## The Day-0 → Day-1 → Day-2 progression
+
+This isn't a checklist you complete once. It is a deliberate sequence.
+
+### Day-0: Foundation
+
+- Catalog populated — services, APIs, and resources registered via `catalog-info.yaml`
+- Software templates defined — teams can create new services following the organization's Golden Paths
+- Authentication configured via `VEECODE_PROFILE` — sets auth provider, catalog discovery, and SCM integrations in one step (see [Configuration Profiles](/devportal/concepts/configuration-profiles))
+
+The portal knows what exists. Engineers can create new services from opinionated templates. Value: reduced onboarding time and consistent project structure.
+
+### Day-1: Connecting services to their tooling
+
+- Enable plugins in `dynamic-plugins.yaml`
+- Add annotations to catalog entities — each annotation is a claim: "this entity owns this Kubernetes workload / this GitLab project / this Grafana dashboard"
+- Configure backends in `app-config.yaml` — tell the backend where to find the external systems
+
+### Day-2: The operational hub
+
+- Developers operate services without leaving the portal
+- CI/CD tabs show pipeline status alongside the service entity
+- Kubernetes tab shows pod health and live logs
+- Grafana cards show dashboards scoped to that specific service
+- Code Quality tab surfaces SonarQube results
+
+The portal is no longer a catalog. It is the operational interface for the service.
+
+---
+
+## Example: internal team portal
+
+A concrete composition — GitLab CI, Grafana observability, and Kubernetes workloads — across the three layers:
+
+**`dynamic-plugins.yaml` — what to load:**
+
+```yaml
+plugins:
+  # Kubernetes — bundled in the image, enable it
+  - package: ./dynamic-plugins/dist/backstage-plugin-kubernetes-dynamic
+    disabled: false
+
+  # GitLab Pipelines — OCI plugin, downloaded at startup
+  - package: oci://quay.io/veecode/gitlab:bs_1.48.4!immobiliarelabs-backstage-plugin-gitlab
+    disabled: false
+
+  # Grafana — OCI plugin, downloaded at startup
+  - package: oci://quay.io/veecode/<workspace>:<tag>!roadiehq-backstage-plugin-grafana
+    disabled: false
+```
+
+**Each service's `catalog-info.yaml` — what it owns:**
+
+```yaml
+metadata:
+  annotations:
+    backstage.io/kubernetes-label-selector: 'app=my-service,env=production'
+    gitlab.com/project-slug: my-group/my-service
+    grafana/dashboard-selector: "tags @> 'my-service'"
+```
+
+**`app-config.yaml` — where to fetch data from:**
+
+```yaml
+kubernetes:
+  serviceLocatorMethod:
+    type: multiTenant
+  clusterLocatorMethods:
+    - type: config
+      clusters:
+        - name: production
+          url: ${K8S_CLUSTER_URL}
+          serviceAccountToken: ${K8S_CLUSTER_TOKEN}
+
+grafana:
+  domain: ${GRAFANA_URL}
+
+integrations:
+  gitlab:
+    - host: gitlab.com
+      token: ${GITLAB_TOKEN}
+```
+
+Result: each service entity has a Kubernetes tab, a CI tab with GitLab pipeline history, and an overview card with Grafana dashboards scoped to that service. Developers see the operational state of their service in one place.
+
+---
+
+## Choosing the right plugins for your context
+
+The question isn't "which plugins are available" — it's "what does my team need to stop context-switching for?"
+
+| If your team uses... | Enable... | Required annotation |
+|---|---|---|
+| GitHub CI | GitHub Actions | `github.com/project-slug: org/repo` |
+| GitHub workflow triggers | GitHub Workflows | `github.com/project-slug` + `github.com/workflows` |
+| GitLab CI | GitLab Pipelines | `gitlab.com/project-slug: group/project` |
+| Jenkins | Jenkins | `jenkins.io/job-full-name: folder/job` |
+| Azure Pipelines | Azure DevOps | `dev.azure.com/project-repo: project/repo` |
+| Kubernetes | Kubernetes | `backstage.io/kubernetes-label-selector: app=name` |
+| Grafana | Grafana | `grafana/dashboard-selector: "tags @> 'name'"` |
+| SonarQube | SonarQube | `sonarqube.org/project-key: project-key` |
+| HashiCorp Vault | Vault | `vault.io/secrets-path: secret/data/service` |
+
+For plugins not in the bundled set, see [Finding Plugins](/devportal/plugins/finding).
+
+---
+
+## References
+
+- [Bundled Plugin Catalog](/devportal/plugins/bundled) — what ships with DevPortal and its default state
+- [Finding Plugins](/devportal/plugins/finding) — plugins beyond the bundled set
+- [Adding Plugins](/devportal/plugins/adding) — OCI and npm download configuration
+- [Configuration Profiles](/devportal/concepts/configuration-profiles) — how `VEECODE_PROFILE` sets Day-0 auth and integrations
+- [Build Your Own Platform](/platform/how-to/build-your-own-platform) — operational playbook for starting from scratch

--- a/platform/concepts/portal-composition.md
+++ b/platform/concepts/portal-composition.md
@@ -66,8 +66,26 @@ A plugin that fails silently has failed at one of these three levels:
 | Symptom | Cause | Fix |
 |---|---|---|
 | Tab not visible on entity | Annotation missing | Add annotation to `catalog-info.yaml` |
-| Tab visible, empty or error | Backend not configured | Check `app-config.yaml` for the relevant integration |
+| Tab visible, empty or error | Backend not configured or unreachable | Check `app-config.yaml` for the relevant integration |
 | Nothing plugin-related works | Plugin not loaded | Check `disabled: false` in `dynamic-plugins.yaml` |
+
+#### Diagnosing "tab appears but is empty or errors"
+
+The plugin is loaded and the annotation is correct, but the data isn't showing. Check in this order:
+
+1. **Backend section exists in `app-config.yaml`** — for Kubernetes: `kubernetes.clusterLocatorMethods`. For Grafana: `grafana.domain`. For SonarQube: `sonarqube.baseUrl` + `apiKey`. Without the backend config, the plugin frontend has no source to query.
+
+2. **The annotation value matches reality** — `backstage.io/kubernetes-label-selector: 'app=my-service'` must match the actual labels on the pods in the cluster. If the pods are labeled `app=myservice` (no hyphen), the plugin returns empty with no UI error.
+
+3. **Credentials and reachability** — the service account token, OAuth credentials, or API key must have read access. The backend must be able to reach the external system (cluster URL, Grafana URL, etc.) from the DevPortal container's network.
+
+4. **TLS settings** — for self-signed certs in `kubernetes.clusterLocatorMethods`, set `skipTLSVerify: true`. Otherwise the connection fails silently from the frontend's perspective.
+
+5. **Backend logs** — connection errors surface in the container logs, not the UI:
+
+   ```bash
+   docker logs devportal | grep -i <plugin-name>
+   ```
 
 ---
 

--- a/platform/intro.md
+++ b/platform/intro.md
@@ -4,6 +4,16 @@ sidebar_label: Platform Intro
 title: Platform Intro
 ---
 
-# Intro
+# Platform Concepts
 
-VeeCode Platform is a set of tools and services that help you to build your own Internal Developer Platform. It follows the principles of "batteries included but swappable", meaning that you can use the platform as is or customize it to meet your specific needs and to embrace your own DevOps culture and tools.
+This section covers the **why** behind the VeeCode Platform: the principles, patterns, and design decisions that inform how the platform is built and how your team should use it.
+
+If you're looking for installation or configuration instructions, that's in [DevPortal](/devportal/intro).
+
+## What's here
+
+- **[Golden Paths](/platform/concepts/golden-paths)** — Why opinionated paths reduce cognitive load and how Software Templates realize them
+- **[Self-Service Design](/platform/concepts/self-service-design)** — What self-service means in practice and what it requires from the platform team
+- **[Capabilities](/platform/capabilities)** — The platform building blocks and how they compose
+
+VeeCode Platform is built on the principle of "batteries included but swappable": you can use it as-is or replace components to match your organization's tooling. The concepts here explain the reasoning behind default choices.

--- a/platform/intro.md
+++ b/platform/intro.md
@@ -4,40 +4,6 @@ sidebar_label: Platform Intro
 title: Platform Intro
 ---
 
-import style from './style.module.css';
-
-:::tip
-We are currently revamping the whole documentation, please come back later to check our improved guides and docs. In the meantime check the other sections of the documentation ([DevPortal](../devportal/intro), [Admin-UI](../admin-ui/intro) and [VKDR-CLI](../vkdr/intro)).
-:::
-
-
 # Intro
 
 VeeCode Platform is a set of tools and services that help you to build your own Internal Developer Platform. It follows the principles of "batteries included but swappable", meaning that you can use the platform as is or customize it to meet your specific needs and to embrace your own DevOps culture and tools.
-
-
-## Hot Shortcuts
-
-You may want to skip documents and go straight to a few key sections, if you are feeling brave.
-
-<div className={style.wrapper}>
-
-export const Card = ({children, title, link}) => (
-   <div className={style.card}
-      onClick={() => window.location = link }
-      onKeyDown={(e) => e.key === 'Enter' && (window.location = link)}
-      tabIndex={0}
-      role="button"
-      aria-label={`Navigate to ${title}`}>
-      <div className={style.titlebar}>
-         <h3 className={style.title}>{title}</h3>
-      </div>
-      <p className={style.desc}>
-         {children}
-      </p>
-   </div>
-);
-
-<Card title="📄️ Self-Service Demo" link="">Explore the platform's features through a simple interactive demo.</Card>
-
-</div>

--- a/platform/intro.md
+++ b/platform/intro.md
@@ -12,6 +12,7 @@ If you're looking for installation or configuration instructions, that's in [Dev
 
 ## What's here
 
+- **[Composing a Portal](/platform/concepts/portal-composition)** — How plugins, catalog, and annotations compose into an operational hub; the three-layer model and Day-0/1/2 progression
 - **[Golden Paths](/platform/concepts/golden-paths)** — Why opinionated paths reduce cognitive load and how Software Templates realize them
 - **[Self-Service Design](/platform/concepts/self-service-design)** — What self-service means in practice and what it requires from the platform team
 - **[Capabilities](/platform/capabilities)** — The platform building blocks and how they compose

--- a/platform/references/_category_.json
+++ b/platform/references/_category_.json
@@ -1,4 +1,5 @@
 {
     "label": "References",
-    "position": 10
+    "position": 10,
+    "link": { "type": "generated-index" }
   }

--- a/src/components/DocCard/index.js
+++ b/src/components/DocCard/index.js
@@ -1,0 +1,13 @@
+import React from 'react';
+import Link from '@docusaurus/Link';
+
+export default function DocCard({ children, title, link, style }) {
+  return (
+    <Link to={link} className={style.card}>
+      <div className={style.titlebar}>
+        <h3 className={style.title}>{title}</h3>
+      </div>
+      <p className={style.desc}>{children}</p>
+    </Link>
+  );
+}


### PR DESCRIPTION
## Summary

Five-commit refactor of the DevPortal + Platform docs aimed at one goal: a new team member with access to the docs + MCP + Claude Code can both **install** the portal AND **understand** why each plugin matters and how pieces compose into a working IDP — without asking anyone.

### What changed, by layer

**1. Navigation (mechanical fixes)**
- 6 `_category_.json` files get `generated-index` link (resolves 404 + sidebar `href="#"`)
- Extracted `DocCard` component using Docusaurus `<Link>` (semantic, accessible)
- Replaced inline `div onClick` card patterns in intros
- Removed "come back later" banner and broken card from `platform/intro`
- Resolved 2 production TODOs

**2. Purpose-first entry points**
- `devportal/intro` now bifurcates: "want to understand why? → Platform Concepts. Want to install? → continue below"
- `platform/intro` is a real entry point, not a stub
- Bidirectional bridge between `software-template` and `golden-paths`

**3. Composition lens — NEW: `platform/concepts/portal-composition.md`**
- The three-layer activation model: **load** (`dynamic-plugins.yaml`) → **context** (entity annotations) → **backend** (`app-config.yaml`)
- Diagnostic table mapping symptoms to layers ("tab not visible" = annotation missing; "tab empty" = backend missing)
- Day-0 → Day-1 → Day-2 progression with concrete config actions
- Worked example: internal portal with GitLab + Grafana + Kubernetes across all three layers
- Plugin-to-annotation reference table

**4. Plugin docs — "why enable" paragraphs (10 files)**
- Every plugin page now opens with the operational problem it solves before the YAML recipe
- Pattern: "without it, devs context-switch to X. With it + annotation Y + backend Z, the entity becomes the operational view"
- Covers: Grafana, GitHub Workflows, GitLab Pipelines, SonarQube, TechDocs, Vault, GitHub Actions, Jenkins, Azure DevOps
- `bundled/index.md` reframed as capability layers, not a flat install list

**5. Concept docs — composition lens**
- `catalog.md` — names catalog as the substrate everything binds to
- `dynamic-plugins.md` — "Loading is step 1 of 3"
- `configuration-hierarchy.md` — "where do I put my override?" quick answer
- `configuration-profiles.md` — explicit `docker exec` command to inspect the profile file; demystifies the "Rodrigo problem" (works without me configuring anything)
- `software-template.md` — "What template execution actually produces" exposes the SCM → catalog-info → Location → wired entity flow
- `iac-template.md` — "Template-of-templates" pattern for app + infra as a single Golden Path
- `environment-cluster-journey` — environments/clusters as catalog entities → eligible for plugin attachment
- `adding.md` + `cicd.md` — short framing notes connecting back to the three-layer model

## Test plan

- [ ] After deploy to `docs-next.platform.vee.codes`, refresh MCP snapshot
- [ ] Run validation prompt with a clean Claude Code session (MCP only): 8 questions covering profile transparency, troubleshooting by symptom, three-plugin composition, plugin-not-documented mental model, config overrides, template-emitted annotations, app+infra composition
- [ ] Confirm previous gaps are now covered (profile file path, troubleshooting checklist, template→annotation link, IaC composition pattern)
- [ ] Spot-check the 6 previously-broken category routes resolve and sidebar items navigate
- [ ] Confirm cards on `devportal/intro` and `installation-guide/intro` are now real anchors (right-click context menu, mid-click new tab)

🤖 Generated with [Claude Code](https://claude.com/claude-code)