### PR TITLE
docs: close 4 comprehension gaps surfaced by validation

### DIFF
--- a/devportal/concepts/iac-template.md
+++ b/devportal/concepts/iac-template.md
@@ -95,6 +95,35 @@ An IaC template can be a step inside a software template. The software template 
 
 This is the mechanism behind a complete [Golden Path](/platform/concepts/golden-paths): the template encodes the organization's standard for what a production-ready service looks like — application code, CI/CD configuration, and infrastructure — as a single self-service operation.
 
+#### Declaring the `dependsOn` link
+
+The link between Component and Resource is a standard Backstage relation, written into the Component's `catalog-info.yaml` under `spec.dependsOn[]`. The template emits it as part of the scaffolded file — the developer never writes it by hand.
+
+```yaml
+# catalog-info.yaml emitted by the software template for the Component
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: payment-service
+  annotations:
+    backstage.io/kubernetes-label-selector: 'app=payment-service'
+    gitlab.com/project-slug: my-group/payment-service
+spec:
+  type: service
+  lifecycle: production
+  owner: checkout-team
+  system: checkout-system
+  dependsOn:
+    - resource:default/payment-db        # provisioned by the IaC template step
+    - resource:default/payment-queue
+```
+
+The referenced Resources are produced by the IaC template invocation inside the same workflow. Once both entities are registered, the Component's overview page shows the dependency graph; the Resources show the reverse `dependencyOf` relation. Catalog providers, RBAC rules, and observability plugins all see the link.
+
+The format is `<kind>:<namespace>/<name>` (lowercase), matching Backstage's entity reference convention.
+
+---
+
 For the three-layer model that governs how the resulting entities connect to plugins, see [Composing a Portal](/platform/concepts/portal-composition). For the software template side of this pattern, see [Software Templates](/devportal/concepts/software-template).
 
 ---

--- a/devportal/installation-guide/docker-local/custom-catalog.md
+++ b/devportal/installation-guide/docker-local/custom-catalog.md
@@ -207,6 +207,31 @@ catalog:
             minutes: 3
 ```
 
+## Replacing vs adding to the demo catalog
+
+The default DevPortal image ships with demo entities registered via `/app/examples/` in `app-config.production.yaml` (see [Docker Run — What's in the demo catalog](./intro#whats-in-the-demo-catalog)). Backstage merges `catalog.locations[]` **additively** across config layers, so understanding the consequence matters:
+
+**Adding alongside the demo (the common case):** Anything you put in `app-config.local.yaml` under `catalog.locations[]` is appended to the demo locations. Both sets will appear in the portal. This is what every example in this page does, and it's almost always what you want for a first contact.
+
+**Removing the demo entirely:** You can't suppress an entry from a lower layer via the local config — `catalog.locations[]` does not support "remove this." The only path is to mount a replacement `app-config.production.yaml` that omits the demo locations:
+
+```bash
+# 1. Extract the existing production yaml as a starting point
+docker cp devportal:/app/app-config.production.yaml ./app-config.production.yaml
+
+# 2. Edit it — remove the /app/examples/* entries from catalog.locations
+#    Keep everything else (baseUrl, CORS, auth, RBAC paths, integrations, etc.)
+
+# 3. Mount your edited version on the next run
+docker run --rm -d -p 7007:7007 \
+  -v $(pwd)/app-config.production.yaml:/app/app-config.production.yaml:ro \
+  veecode/devportal:latest
+```
+
+:::warning
+Mounting your own `app-config.production.yaml` replaces the file entirely. Make sure you start from the version in the image you're actually using — values change between releases. Re-extract after every image upgrade.
+:::
+
 ## Next Steps
 
 - [Custom App Configuration](./custom-config)

--- a/devportal/installation-guide/docker-local/intro.md
+++ b/devportal/installation-guide/docker-local/intro.md
@@ -77,11 +77,49 @@ import SetupDefaults from '@site/static/img/docker-setup/setup-defaults.png';
 Points to notice:
 
 - "Guest" authentication enabled as an admin user ("user:default/admin", "group:default/admins", "role:default/admin" with all permissions granted).
-- The catalog will be populated with a built-in catalog for demo purposes (folder "/app/examples" inside the containers).
+- The catalog is populated with built-in demo entities (see [What's in the demo catalog](#whats-in-the-demo-catalog) below).
 - The container loads several config files in a defined precedence order. Your custom file at `/app/app-config.local.yaml` overrides the base and profile defaults. See [Custom Configuration](./custom-config) for the full merge order.
 - There are many plugins already bundled in the container image, ready to be enabled. You can mount the `/app/dynamic-plugins.yaml` plugin file to enable those you want to use.
 
 We will talk more about these subjects later on, but understand there are many possible ways to extend and configure DevPortal container without rebuilding it (or making a derived image).
+
+## What's in the demo catalog
+
+When you run `veecode/devportal:latest` with no custom config, the catalog is **not empty by accident** — it is populated from `/app/examples/` inside the image. Knowing what's in there matters because (a) you can read these files as concrete examples of how every entity kind is declared, and (b) you need a strategy for replacing them when you go beyond the demo.
+
+The demo data lives in these files (you can inspect them directly with `docker exec`):
+
+```bash
+docker exec devportal ls /app/examples/
+docker exec devportal cat /app/examples/entities.yaml
+```
+
+| File | What it contains |
+|---|---|
+| `entities.yaml` | System (`examples`), Components (`example-website`, `example-node-app`), an inline gRPC API |
+| `org.yaml` | Users (`guest`, `admin`) and Groups (`guests`, `admins`, `developers`) |
+| `apis.yaml` | A live OpenAPI from `apis.guru` (loaded via `$openapi` remote ref) and a gRPC API |
+| `resources.yaml` | Demo Resources — a database, vault, bucket, and two environment-typed Resources |
+| `clusters.yaml` | A cluster Resource (`my-own-cluster`) |
+| `techdocs/catalog-info.yaml` | A Component with TechDocs enabled (good reference for TechDocs annotation usage) |
+| `template-nodejs/template.yaml` | Scaffolder Template that creates a Node.js service repo on GitHub |
+| `template-openapi/template.yaml` | Scaffolder Template that generates a Kong deck config from an OpenAPI spec |
+| `template-azure-nodejs/template.yaml` | Variant of the Node.js template targeting Azure DevOps |
+
+These files are registered as catalog locations in `app-config.production.yaml`, which is one of the layered configs loaded on startup. That is why they appear out of the box.
+
+:::warning Demo Templates need credentials to execute
+The three demo Templates appear in the **Create** tab but will fail at execution unless you provide the relevant secrets (GitHub token for `example-nodejs-template` and `template-openapi`, Kong connection for `template-openapi`, Azure DevOps PAT for `template-azure-nodejs`). They are useful as examples of template structure even if you don't run them.
+:::
+
+### Replacing the demo catalog
+
+`catalog.locations[]` is **additive** in Backstage's config merge — entries from `app-config.local.yaml` are appended to (not substituted for) the ones in `app-config.production.yaml`. This means:
+
+- **Adding your own entities alongside the demo:** mount your own `catalog-info.yaml` and add it as a location in `app-config.local.yaml`. Both sets will appear.
+- **Fully removing the demo entities:** mount a replacement `app-config.production.yaml` that omits the `/app/examples/` entries. You must preserve all the other settings from the original (baseUrl, CORS, auth, RBAC paths, etc.) — only do this when you intentionally want a clean catalog.
+
+See [Custom Catalog](./custom-catalog#replacing-vs-adding-to-the-demo-catalog) for the concrete YAML.
 
 ## Next Steps
 

--- a/devportal/plugins/adding.md
+++ b/devportal/plugins/adding.md
@@ -69,23 +69,47 @@ OCI artifacts published by VeeCode follow this format:
 oci://quay.io/veecode/<workspace>:bs_<backstage-version>!<plugin-name>
 ```
 
-- **workspace**: workspace name in the export-overlays pipeline (e.g., `gitlab`, `tech-insights`, `aws-ecs`)
-- **backstage-version**: Backstage version of your instance (e.g., `1.49.4`)
-- **plugin-name**: npm package name with `@` removed and `/` replaced by `-` (e.g., `immobiliarelabs-backstage-plugin-gitlab`)
+- **workspace**: directory name under `workspaces/` in the [`devportal-plugin-export-overlays`](https://github.com/veecode-platform/devportal-plugin-export-overlays) repo (e.g., `gitlab`, `tech-insights`, `roadie-backstage-plugins`). Each workspace bundles all plugins from one upstream source into a single image; the `!<plugin-name>` part of the reference selects the specific plugin inside that image.
+- **backstage-version**: Backstage version of your DevPortal instance (e.g., `bs_1.49.4`). Must match — a plugin built for `1.48.4` will not load on a `1.49.4` instance.
+- **plugin-name**: npm package name with `@` removed and `/` replaced by `-`. Examples: `@immobiliarelabs/backstage-plugin-gitlab` → `immobiliarelabs-backstage-plugin-gitlab`; `@roadiehq/backstage-plugin-argo-cd` → `roadiehq-backstage-plugin-argo-cd`.
 
-Available workspaces on `quay.io/veecode`:
+### Finding the OCI reference for a plugin
 
-| Workspace | Plugins | Tag |
-|---|---|---|
-| `gitlab` | GitLab frontend + backend (immobiliare) | `bs_1.48.4` |
-| `tech-insights` | Tech Insights frontend, backend, jsonfc | `bs_1.48.4` |
-| `aws-ecs` | AWS ECS frontend + backend | `bs_1.48.4` |
-| `mcp-integrations` | MCP extras (catalog, techdocs, scaffolder) | `bs_1.49.4` |
-| `backstage` | MCP actions backend | `bs_1.49.4` |
-| `mcp-chat` | MCP Chat frontend + backend | `bs_1.49.4` |
+Common workspaces you will see in the wild:
+
+| Workspace | Provides |
+|---|---|
+| `gitlab` | GitLab integration (immobiliarelabs) |
+| `tech-insights` | Tech Insights scorecards |
+| `roadie-backstage-plugins` | Roadie community plugins (Argo CD, AWS, etc.) |
+| `argocd` | Argo CD plugin |
+| `sonarqube` | SonarQube quality scorecards |
+| `keycloak` | Keycloak SSO + group sync |
+| `mcp-integrations` / `mcp-chat` | MCP plugins |
+
+This list is not exhaustive — there are 60+ workspaces. For any plugin not in the table, use one of the two discovery paths below.
+
+**Path A — Marketplace (fastest).** Open the in-portal Marketplace, search for the plugin, and the card shows the exact `package:` reference to copy into your YAML. The Marketplace consumes `quay.io/veecode/plugin-catalog-index:latest`, which aggregates every published plugin's metadata — so this is the most up-to-date index.
+
+**Path B — Inspect the export-overlays repo (when you need to verify or you don't have Marketplace access).**
+
+1. Open [`veecode-platform/devportal-plugin-export-overlays`](https://github.com/veecode-platform/devportal-plugin-export-overlays/tree/main/workspaces).
+2. Find the workspace that packages the plugin's upstream repo. The workspace name usually matches the upstream npm scope or repo: `@roadiehq/*` → `roadie-backstage-plugins`; `@immobiliarelabs/backstage-plugin-gitlab` → `gitlab`; standalone plugins like `argocd` get their own workspace.
+3. Open `workspaces/<workspace>/plugins-list.yaml`. **If the plugin is commented out, it is not currently published — there is no OCI artifact for it.**
+4. If active, open `workspaces/<workspace>/metadata/<plugin-name>.yaml`. The `dynamicArtifact` field is the authoritative OCI reference to copy into your `dynamic-plugins.yaml`.
+
+```bash
+# Programmatic search across all workspaces:
+git clone https://github.com/veecode-platform/devportal-plugin-export-overlays
+grep -r "dynamicArtifact" workspaces/ | grep -i "<plugin-name-substring>"
+```
+
+:::caution Not every Backstage plugin is published as an OCI artifact by VeeCode
+If a plugin's `plugins-list.yaml` entry is commented out (or the plugin doesn't appear in any workspace), VeeCode is not currently shipping a dynamic build for it. You can still enable it by referencing the npm package directly (`package: '@npm-scope/plugin-name'`) provided the upstream publishes a dynamic build, or you can fork `devportal-plugin-export-overlays` and add the plugin to a workspace yourself.
+:::
 
 :::note
-The workspace tag must match the Backstage version of your DevPortal instance. The examples above reflect current published tags; MCP workspaces are on `bs_1.49.4` while others are on `bs_1.48.4`. The workspace table above is not exhaustive — there are 60+ workspaces in the export-overlays pipeline. Use the Marketplace for the complete catalog.
+The README of `devportal-plugin-export-overlays` is partially stale — it mentions `ghcr.io/veecode-platform/...` as the registry and a `bs_<version>__<plugin-version>` tag format. The actual published artifacts use `quay.io/veecode/...` with `bs_<version>` only. Trust the `dynamicArtifact` field in each plugin's `metadata/<plugin>.yaml` — that's what the CI pipeline writes and what the Marketplace reads.
 :::
 
 For a complete list of bundled (preloaded) plugins that do not require an OCI reference, see [Bundled Plugins](./bundled).

--- a/devportal/plugins/grafana.md
+++ b/devportal/plugins/grafana.md
@@ -10,8 +10,16 @@ Without this plugin, Grafana dashboards are a separate tab the developer has to 
 
 The Grafana plugin embeds Grafana dashboards and alert panels in entity pages, giving developers direct observability access from the catalog.
 
-:::note
-The Grafana plugin is **not bundled** in the DevPortal image. It must be added as an external dynamic plugin via `dynamic-plugins.yaml` or the Marketplace. No support plan is required — the plugin is a standard Backstage community plugin available publicly.
+:::caution Grafana is not currently published as an OCI artifact by VeeCode
+The `@roadiehq/backstage-plugin-grafana` package exists upstream (Roadie community plugins) but is **not** in any active workspace in [`devportal-plugin-export-overlays`](https://github.com/veecode-platform/devportal-plugin-export-overlays) — the entry is commented out in the `roadie-backstage-plugins` workspace, which means VeeCode is not currently publishing an OCI image for it.
+
+Your options:
+
+1. **Reference the npm package directly** — if upstream Roadie publishes a dynamic build of this plugin, you can use `package: '@roadiehq/backstage-plugin-grafana'` in `dynamic-plugins.yaml`. Confirm upstream has a `-dynamic` artifact before relying on this.
+2. **Fork [`devportal-plugin-export-overlays`](https://github.com/veecode-platform/devportal-plugin-export-overlays)** and add the plugin to a workspace yourself, then publish your own OCI artifact.
+3. **Use an alternative** — for ready-to-use observability/quality plugins that VeeCode publishes today, see [Tech Insights](./bundled), [SonarQube](./Sonar), or the `kiali` workspace for service-mesh observability.
+
+The configuration below shows the composition contract (annotation + backend config) regardless of which installation path you choose.
 :::
 
 ---
@@ -20,13 +28,11 @@ The Grafana plugin is **not bundled** in the DevPortal image. It must be added a
 
 ### Via Marketplace
 
-Search for "Grafana" in the DevPortal Marketplace and click **Enable**. The Marketplace handles the OCI reference and mount point configuration automatically.
+If the Marketplace shows a Grafana plugin entry (the catalog is updated continuously), click **Enable** and skip the manual steps below.
 
 ### Via `dynamic-plugins.yaml`
 
-Add the Grafana plugin from the community OCI registry. Check the [Marketplace](../plugins/finding) or the [Backstage Plugin Registry](https://backstage.io/plugins) for the current OCI reference and workspace tag that matches your DevPortal's Backstage version.
-
-A typical entry looks like:
+If the OCI artifact is not available, you can still reference the upstream npm package or your own build. The illustrative OCI entry below uses placeholder workspace/tag — see the caution box above for the current publishing status.
 
 ```yaml
 plugins:

--- a/platform/concepts/portal-composition.md
+++ b/platform/concepts/portal-composition.md
@@ -61,13 +61,48 @@ Without this, the tab loads and shows an error or empty state. With all three la
 
 ### The diagnostic model
 
-A plugin that fails silently has failed at one of these three levels:
+A plugin that fails silently has failed at one of these three levels. Diagnose in layer order — load before context before backend, because each layer assumes the previous one succeeded.
 
-| Symptom | Cause | Fix |
+| Symptom | Layer | Fix |
 |---|---|---|
-| Tab not visible on entity | Annotation missing | Add annotation to `catalog-info.yaml` |
-| Tab visible, empty or error | Backend not configured or unreachable | Check `app-config.yaml` for the relevant integration |
-| Nothing plugin-related works | Plugin not loaded | Check `disabled: false` in `dynamic-plugins.yaml` |
+| Plugin entirely absent (no tab, no card, nothing) on any entity | Load — declared but installer failed | See [Diagnosing "plugin not loaded"](#diagnosing-plugin-not-loaded) below |
+| Tab not visible on a specific entity | Context — annotation missing | Add the annotation to that entity's `catalog-info.yaml` |
+| Tab visible, empty or error | Backend — configuration missing or unreachable | Check `app-config.yaml` for the relevant integration |
+
+#### Diagnosing "plugin not loaded"
+
+This is the trickiest failure to spot because **the portal still boots normally** — there is no startup error, no banner, no warning in the UI. The plugin is simply absent.
+
+The DevPortal entrypoint runs `install-dynamic-plugins.py` before starting Backstage. The installer reads `dynamic-plugins.yaml`, downloads each OCI/npm artifact, and writes the merged config that Backstage reads on boot. The installer is best-effort: when it fails for a specific plugin, it logs an error, **skips that plugin, and continues**. Backstage then boots without it. If you're not looking at the logs, the plugin just isn't there.
+
+Check the container logs for the specific install lifecycle lines the installer prints:
+
+```bash
+docker logs devportal 2>&1 | grep -E "======= (Installing|Skipping|Successfully|ERROR|Using pre-installed)"
+```
+
+What you should see for a healthy load:
+
+```
+======= Installing dynamic plugin <package>
+==> Successfully installed dynamic plugin <package>
+```
+
+Common failure signatures and what they mean:
+
+| Log signature | What happened | Likely cause |
+|---|---|---|
+| `======= ERROR: Failed to install plugin ... npm ERR! 404` | npm package or version doesn't exist | Typo in `package:`, or version not published |
+| `======= ERROR: Failed to install OCI plugin ... skopeo ... non-zero exit status 1` | OCI image not found or unreachable | Wrong workspace, wrong tag, registry unreachable, or plugin commented out in [`devportal-plugin-export-overlays`](https://github.com/veecode-platform/devportal-plugin-export-overlays) — see [Finding the OCI reference](/devportal/plugins/adding#finding-the-oci-reference-for-a-plugin) |
+| `======= ERROR: ... hash of the downloaded package ... does not match the provided integrity hash` | Tampered or wrong-version artifact | Regenerate or remove the `integrity:` field |
+| `yaml.scanner.ScannerError:` or `yaml.parser.ParserError:` | `dynamic-plugins.yaml` itself doesn't parse | YAML syntax error — duplicate keys, bad indentation. **No plugins load at all when this happens.** |
+| `InstallException: Config key '...' defined differently for 2 dynamic plugins` | Two plugins set the same config key incompatibly | Reconcile the conflicting `pluginConfig` entries |
+| `InstallException: skopeo executable not found in PATH` | OCI install attempted on an image that doesn't have skopeo | Use the official VeeCode image, or switch to npm packages |
+| No `Installing` line for the plugin at all | The package name in your YAML doesn't match anything that was processed | Typo in `package:`, or the entry is inside an `includes:` file that wasn't found |
+
+:::caution Installer crashes are non-fatal
+A Python crash in `install-dynamic-plugins.py` does not abort the boot. The portal starts anyway, with `app-config.dynamic-plugins.yaml` either stale or empty. After any change to `dynamic-plugins.yaml`, verify the install lifecycle lines above before assuming the plugin is active.
+:::
 
 #### Diagnosing "tab appears but is empty or errors"
 
@@ -135,10 +170,16 @@ plugins:
   - package: oci://quay.io/veecode/gitlab:bs_1.48.4!immobiliarelabs-backstage-plugin-gitlab
     disabled: false
 
-  # Grafana — OCI plugin, downloaded at startup
+  # Grafana — see note below; reference is illustrative
   - package: oci://quay.io/veecode/<workspace>:<tag>!roadiehq-backstage-plugin-grafana
     disabled: false
 ```
+
+:::note Grafana is not currently published as an OCI artifact by VeeCode
+The `@roadiehq/backstage-plugin-grafana` package exists upstream but is not in any active workspace in [`devportal-plugin-export-overlays`](https://github.com/veecode-platform/devportal-plugin-export-overlays). To use Grafana today you have two options: reference the npm package directly (`package: '@roadiehq/backstage-plugin-grafana'`) if upstream publishes a dynamic build, or fork `devportal-plugin-export-overlays` and add the plugin to a workspace. For ready-to-use observability and quality plugins that ARE published as OCI, see [Tech Insights](/devportal/plugins/bundled), [SonarQube](/devportal/plugins/Sonar), or `kiali` (service mesh).
+
+The composition model below applies identically — once loaded by either route, Grafana follows the same Layer 1 / 2 / 3 rules.
+:::
 
 **Each service's `catalog-info.yaml` — what it owns:**
 


### PR DESCRIPTION
## Summary

Follow-up to #18. The validation pass surfaced 4 gaps that look like style on the surface but are conceptual on closer inspection — each is a piece of factual information a clean agent could not reach from the docs alone. Every fact in this PR was verified against the actual VeeCode repos (`devportal-plugin-export-overlays`, `devportal-base`, `devportal-distro`) before writing.

- **Gap 1 — OCI plugin discovery** (`adding.md`): the old workspace table was partial (7 of 60+) and the rest was a "check the Marketplace" shrug. Replaced with the actual discovery method using `workspaces/<ws>/metadata/<plugin>.yaml` and the `dynamicArtifact` field, plus a callout that the repo's own README is partially stale.
- **Gap 2 — Load-failure diagnostics** (`portal-composition.md`): the existing three-layer diagnostic table assumed Load succeeded. Added a "plugin not loaded" subsection with concrete `install-dynamic-plugins.py` log signatures, and made explicit the critical fact that `entrypoint.sh` does not gate on the installer's exit code — so the portal boots without the plugin silently when the installer crashes. This was the missing piece explaining several past "plugin disappeared" incidents.
- **Gap 3 — Demo catalog transparency** (`docker-local/intro.md`, `custom-catalog.md`): the quickstart left users with a populated catalog and no explanation of where it came from. Documented `/app/examples/` contents, how `app-config.production.yaml` registers them, and the additivity caveat (you can't suppress demo entries from `app-config.local.yaml` — `catalog.locations[]` is additive across layers).
- **Gap 4 — `dependsOn` YAML** (`iac-template.md`): template-of-templates section mentioned the relation without showing the syntax. Added a concrete Component → Resource snippet.

### Bonus correction

Validation surfaced that the Grafana example in `portal-composition.md` references a workspace that doesn't exist — Grafana is **not currently published as an OCI artifact by VeeCode** (commented out in the `roadie-backstage-plugins` workspace). Kept Grafana in the central composition example because it's the clearest "observability" illustration, but added callouts in `portal-composition.md` and `grafana.md` explaining the current status and listing alternatives (Tech Insights, SonarQube, Kiali) that ARE published.

## Test plan

- [x] `yarn build` passes locally (only pre-existing `admin-ui` broken-anchor warning, unrelated)
- [ ] Pages deploy succeeds on merge
- [ ] MCP republish picks up the new content (publishes from `main`)
- [ ] Re-run the validation prompt on a clean Claude Code session after MCP republish — the same 4 gap-related questions should now be answerable from docs only

🤖 Generated with [Claude Code](https://claude.com/claude-code)