### PR TITLE
docs: close residual operational gaps before team rollout

### DIFF
--- a/devportal/plugins/adding.md
+++ b/devportal/plugins/adding.md
@@ -70,8 +70,30 @@ oci://quay.io/veecode/<workspace>:bs_<backstage-version>!<plugin-name>
 ```
 
 - **workspace**: directory name under `workspaces/` in the [`devportal-plugin-export-overlays`](https://github.com/veecode-platform/devportal-plugin-export-overlays) repo (e.g., `gitlab`, `tech-insights`, `roadie-backstage-plugins`). Each workspace bundles all plugins from one upstream source into a single image; the `!<plugin-name>` part of the reference selects the specific plugin inside that image.
-- **backstage-version**: Backstage version of your DevPortal instance (e.g., `bs_1.49.4`). Must match — a plugin built for `1.48.4` will not load on a `1.49.4` instance.
+- **backstage-version**: Backstage version of your DevPortal instance (e.g., `bs_1.49.4`). Must match — a plugin built for `1.48.4` will not load on a `1.49.4` instance. See [Discovering your Backstage version](#discovering-your-backstage-version) below.
 - **plugin-name**: npm package name with `@` removed and `/` replaced by `-`. Examples: `@immobiliarelabs/backstage-plugin-gitlab` → `immobiliarelabs-backstage-plugin-gitlab`; `@roadiehq/backstage-plugin-argo-cd` → `roadiehq-backstage-plugin-argo-cd`.
+
+#### Discovering your Backstage version
+
+Every OCI reference is built for a specific Backstage release. To find which release your DevPortal image is on, inspect `/app/dynamic-plugins.default.yaml` — every entry in that file carries a `bs_<version>` tag and they're all the same:
+
+```bash
+# On a running container
+docker exec <container> sh -c \
+  "grep -o 'bs_[0-9.]*' /app/dynamic-plugins.default.yaml | sort -u | head -1"
+
+# On the image directly, without a running container
+docker run --rm veecode/devportal:latest \
+  grep -o 'bs_[0-9.]*' /app/dynamic-plugins.default.yaml | sort -u | head -1
+```
+
+Output is the tag string to use, e.g. `bs_1.49.4`. Plug it into the `<backstage-version>` slot in your OCI reference.
+
+:::note Why not other methods?
+- The image labels (`docker inspect`) only carry UBI/RHEL base image metadata — no Backstage version.
+- The `/api/version` endpoint exists but requires authentication, so it's not usable for a quick check.
+- The `@backstage/backend-defaults` version inside `/app/packages/backend/package.json` is a Backstage-internal pin (e.g., `^0.16.0`), not the public Backstage release number — different namespace, don't use it.
+:::
 
 ### Finding the OCI reference for a plugin
 
@@ -96,7 +118,7 @@ This list is not exhaustive — there are 60+ workspaces. For any plugin not in 
 1. Open [`veecode-platform/devportal-plugin-export-overlays`](https://github.com/veecode-platform/devportal-plugin-export-overlays/tree/main/workspaces).
 2. Find the workspace that packages the plugin's upstream repo. The workspace name usually matches the upstream npm scope or repo: `@roadiehq/*` → `roadie-backstage-plugins`; `@immobiliarelabs/backstage-plugin-gitlab` → `gitlab`; standalone plugins like `argocd` get their own workspace.
 3. Open `workspaces/<workspace>/plugins-list.yaml`. **If the plugin is commented out, it is not currently published — there is no OCI artifact for it.**
-4. If active, open `workspaces/<workspace>/metadata/<plugin-name>.yaml`. The `dynamicArtifact` field is the authoritative OCI reference to copy into your `dynamic-plugins.yaml`.
+4. If active, open `workspaces/<workspace>/metadata/<plugin-name>.yaml`. The `dynamicArtifact` field is the authoritative reference to copy into your `dynamic-plugins.yaml`.
 
 ```bash
 # Programmatic search across all workspaces:
@@ -104,9 +126,26 @@ git clone https://github.com/veecode-platform/devportal-plugin-export-overlays
 grep -r "dynamicArtifact" workspaces/ | grep -i "<plugin-name-substring>"
 ```
 
+:::caution `dynamicArtifact` can also be a local path — not all entries are OCI references
+Most `dynamicArtifact` values look like `oci://quay.io/veecode/<workspace>:bs_<version>!<plugin-name>` and are usable directly in any DevPortal. **But some entries are local paths** like `./dynamic-plugins/dist/<plugin-name>`. That syntax means the plugin is **preloaded inside the DevPortal image** — it is not available as a pull-at-runtime OCI artifact, and you cannot use that string in your own `dynamic-plugins.yaml` unless your distro already bundles the plugin's `dist/` folder. If you need the plugin and the `dynamicArtifact` is a local path, your options are: rebuild your own image with the plugin bundled, or fork `devportal-plugin-export-overlays` and add an OCI export step for it.
+:::
+
 :::caution Not every Backstage plugin is published as an OCI artifact by VeeCode
 If a plugin's `plugins-list.yaml` entry is commented out (or the plugin doesn't appear in any workspace), VeeCode is not currently shipping a dynamic build for it. You can still enable it by referencing the npm package directly (`package: '@npm-scope/plugin-name'`) provided the upstream publishes a dynamic build, or you can fork `devportal-plugin-export-overlays` and add the plugin to a workspace yourself.
 :::
+
+#### When two workspaces could plausibly contain the same plugin
+
+Some upstream functionalities are implemented by **multiple independent npm packages** from different vendors — Argo CD is the canonical example. The community publishes one implementation; Roadie publishes another. Both can be found in the export-overlays repo, in different workspaces. Pick deliberately:
+
+| You want... | Use workspace | Packages |
+|---|---|---|
+| Argo CD deployment status + history, OCI-available frontend + backend | `argocd` | `@backstage-community/plugin-argocd` (frontend, OCI) + `@backstage-community/plugin-argocd-backend` (backend, OCI) |
+| Roadie's Argo CD overview cards + a scaffolder action to create Argo CD resources | `roadie-backstage-plugins` | `@roadiehq/backstage-plugin-argo-cd-backend` (OCI) + `@roadiehq/scaffolder-backend-argocd` (OCI). **The Roadie frontend has no OCI artifact** (its `dynamicArtifact` is a local path) — pair the Roadie backend with a custom-bundled frontend, or use the community frontend instead. |
+
+The two implementations share the same `argocd.appLocatorMethods` schema in `app-config.yaml`, so you can swap which backend you load without rewriting your config — but they expose different frontend component names and entity card layouts.
+
+The same disambiguation pattern applies whenever you see plugins from `@backstage-community/*` and `@roadiehq/*` (or any other vendor) for the same upstream tool. Check both workspaces, compare features, and pick the one whose frontend exists as OCI if you need pull-at-runtime install.
 
 :::note
 The README of `devportal-plugin-export-overlays` is partially stale — it mentions `ghcr.io/veecode-platform/...` as the registry and a `bs_<version>__<plugin-version>` tag format. The actual published artifacts use `quay.io/veecode/...` with `bs_<version>` only. Trust the `dynamicArtifact` field in each plugin's `metadata/<plugin>.yaml` — that's what the CI pipeline writes and what the Marketplace reads.

--- a/devportal/plugins/development/loading.md
+++ b/devportal/plugins/development/loading.md
@@ -44,6 +44,37 @@ global:
 
 Both surfaces accept the same plugin entry format. The `dynamic-plugins.yaml` approach is recommended for non-Helm deployments.
 
+## Generating the `integrity` hash
+
+The `integrity:` field is **required for remote npm packages** (unless the env var `SKIP_INTEGRITY_CHECK=true` is set). The installer downloads the package, recomputes its SHA-512, and refuses to load it on mismatch.
+
+It is **not used** for:
+
+- OCI packages (`oci://...`) — these are validated by digest comparison via `skopeo inspect`.
+- Local paths (`./dynamic-plugins/dist/...`) — pre-bundled in the image; no download involved.
+
+Expected format: `sha512-<base64>`. Two ways to generate it:
+
+**Method A — query the npm registry directly (preferred for public packages):**
+
+```bash
+npm view <package>@<version> dist.integrity
+# example
+npm view @backstage/plugin-catalog@2.0.5 dist.integrity
+```
+
+Returns the hash in exactly the format the installer compares against. **Always pin the version** — `npm view <package> dist.integrity` (no version) returns the latest, which will mismatch if you have a specific version pinned in your `package:` field.
+
+**Method B — compute it locally (fallback for private registries or when `npm view` fails):**
+
+```bash
+npm pack <package>@<version> && \
+  HASH=$(cat <package>-<version>.tgz | openssl dgst -sha512 -binary | openssl base64 -A) && \
+  echo "sha512-$HASH"
+```
+
+This replicates the exact pipeline the installer uses internally (`cat archive | openssl dgst -sha512 -binary | openssl base64 -A`), so the produced hash is guaranteed to match a successful install.
+
 ## Private npm registry
 
 Due to security and compliance reasons you may not want VeeCode DevPortal to load plugins from public npm registries. You may prefer to use a private npm registry, like Nexus, Artifactory or even Verdaccio.
@@ -72,32 +103,68 @@ kubectl create secret generic veecode-devportal-dynamic-plugins-npmrc \
 
 ## Wiring plugins
 
-Dynamic plugins have the ability to wire themselves to the DevPortal instance configuration. **This is a critical feature** because unlike static plugins they cannot imply in code changes to the host Backstage project.
+Dynamic plugins wire themselves to the DevPortal instance through configuration. Unlike static plugins, they cannot modify the host Backstage project's code — wiring happens at runtime, declared in YAML.
 
-Backend plugins should be detected and loaded automatically, but frontend plugins must be wired by `pluginConfig:` to the DevPortal instance.
+**The wiring rule depends on the plugin's role**, declared in its `package.json` under `backstage.role`:
 
-All dynamic plugins can bring their own settings in the `pluginConfig:` field:
+| Role | `pluginConfig` needed? | Where does its config go? |
+|---|---|---|
+| `frontend-plugin` | **Yes** — describes mount points, tabs, routes | Inside `pluginConfig.dynamicPlugins.frontend.<plugin-id>` |
+| `backend-plugin` | **No** — auto-discovered by the loader | Plain top-level keys in `app-config.yaml` (e.g., `sonarqube:`, `gitlab:`) |
+| `backend-plugin-module` | **No** — auto-attaches to its parent plugin | Plain top-level keys in `app-config.yaml` (parent plugin's config) |
+
+There is no `dynamicPlugins.backend.*` key. Backend plugins never wire themselves through `pluginConfig` — the loader detects them by their package role and registers them automatically.
+
+### Backend plugin example (no `pluginConfig`)
 
 ```yaml
-  dynamic:
-    plugins:
-      # npm plugin
-      - package: '@yourorg/yourplugin@x.y.z'
-        disabled: false
-        integrity: sha512-xxxxxxxxx
-        pluginConfig:
-          dynamicPlugins:
-            something:
-              morethings:
-                - foo
-                - bar
+plugins:
+  - package: oci://quay.io/veecode/sonarqube:bs_1.49.4!backstage-community-plugin-sonarqube-backend
+    disabled: false
+    # No pluginConfig — backend role is auto-discovered
 ```
 
-:::important
-The `pluginConfig` field affects frontend plugins and backend plugins differently. Backend plugins will have their content merged with Backstage "appConfig", while frontend plugins will have their content processed by the "scalprum" component (who will then define routes, sidebars, mount points, icons, APIs, etc.).
-:::
+The plugin's runtime configuration goes in your regular `app-config.yaml` (or `app-config.local.yaml`) as a normal top-level section:
 
-Please check our [Wiring a Frontend Plugin](wiring.md) page for more info on this subject.
+```yaml
+sonarqube:
+  baseUrl: ${SONARQUBE_URL}
+  apiKey: ${SONARQUBE_TOKEN}
+```
+
+Same pattern for `backend-plugin-module` (e.g., a scaffolder action module attaches itself to the scaffolder plugin):
+
+```yaml
+plugins:
+  - package: oci://quay.io/veecode/roadie-backstage-plugins:bs_1.49.4!roadiehq-scaffolder-backend-argocd
+    disabled: false
+    # No pluginConfig — module auto-attaches to the scaffolder backend
+```
+
+### Frontend plugin example (`pluginConfig` required)
+
+Frontend plugins must declare where their UI components mount, because Backstage's frontend has no auto-discovery for routes, sidebars, tabs, or cards:
+
+```yaml
+plugins:
+  - package: oci://quay.io/veecode/sonarqube:bs_1.49.4!backstage-community-plugin-sonarqube
+    disabled: false
+    pluginConfig:
+      dynamicPlugins:
+        frontend:
+          backstage-community.plugin-sonarqube:
+            mountPoints:
+              - mountPoint: entity.page.overview/cards
+                importName: EntitySonarQubeCard
+                config:
+                  if:
+                    allOf:
+                      - isSonarQubeAvailable
+```
+
+The plugin-id under `dynamicPlugins.frontend.<plugin-id>` is the npm package name with `@` removed and `/` replaced by `.` (note: `.`, not `-`, for this key specifically — different from the OCI reference convention).
+
+See [Wiring a Frontend Plugin](wiring.md) for the full list of frontend mount points, tab paths, and the `scalprum` mechanism that processes these declarations at runtime.
 
 ## Tips
 


### PR DESCRIPTION
## Summary

Follow-up to #19. The second validation pass confirmed all conceptual gaps were closed but surfaced three small operational gaps and one ambiguity — each forces the reader to guess or leave the docs to find a real answer. This PR closes them so nothing's left when the docs are shared with the team. Every fact was verified against the live image and source (`devportal-distro`, `devportal-plugin-export-overlays`, and a live pull of `veecode/devportal:latest`).

- **Discovering your Backstage version** (`adding.md`) — The OCI reference requires `bs_<version>` matching the instance, but the docs never said how to look up your instance's version. Added two `docker` one-liners that parse `/app/dynamic-plugins.default.yaml`. Verified on `veecode/devportal:latest` = `bs_1.49.4`. Documented why the obvious alternatives (image labels, `/api/version`, `@backstage/backend-defaults` version) don't work.
- **Generating the `integrity` hash** (`loading.md`) — Examples showed `integrity: sha512-xxxxxxxxx` without saying how to produce it. Added `npm view <pkg>@<ver> dist.integrity` and a local fallback that replicates `install-dynamic-plugins.py`'s verification pipeline exactly. Made explicit that `integrity:` is npm-only — OCI uses digest comparison via `skopeo`.
- **Backend vs frontend `pluginConfig`** (`loading.md`) — The doc implied backend plugins have their own `pluginConfig` variant when in fact **no `dynamicPlugins.backend.*` key exists** — backend plugins never use `pluginConfig`. Rewrote the "Wiring plugins" section with a role-based table and concrete examples for `frontend-plugin`, `backend-plugin`, and `backend-plugin-module`, using real published plugin names.
- **Argo CD disambiguation + local-path `dynamicArtifact`** (`adding.md`) — Two workspaces publish Argo CD plugins (`argocd` = Backstage community; `roadie-backstage-plugins` = Roadie). The docs gave no guidance on choosing. Added a disambiguation table, including the critical fact that the **Roadie frontend's `dynamicArtifact` is a local path** (`./dynamic-plugins/dist/...`) — not pullable at runtime. Also added a general caution explaining that `dynamicArtifact` can be either `oci://` or a local-path string, and what each implies for the user.

## Test plan

- [x] `yarn build` passes locally (only pre-existing `admin-ui` broken-anchor warning, unrelated)
- [ ] Pages deploy succeeds on merge
- [ ] MCP republish picks up the new content
- [ ] Re-run the polish validation prompt on a clean session — none of the 4 issues above should surface again

🤖 Generated with [Claude Code](https://claude.com/claude-code)