### PR TITLE
release: promote develop to main (integrity-hash pointer)

### DIFF
--- a/devportal/plugins/adding.md
+++ b/devportal/plugins/adding.md
@@ -182,6 +182,12 @@ global:
                     importName: DynamicGlobalFloatingActionButton
 ```
 
+:::note `integrity:` is npm-only — and required
+The `integrity:` field is **required for remote npm packages** (unless `SKIP_INTEGRITY_CHECK=true` is set). It is **not used** for OCI packages (`oci://...`, validated by digest comparison) or local paths (`./dynamic-plugins/dist/...`, pre-bundled in the image).
+
+To generate the `sha512-<base64>` string, see [Generating the integrity hash](./development/loading#generating-the-integrity-hash) — covers both `npm view <pkg>@<ver> dist.integrity` (preferred) and an `openssl`-based fallback.
+:::
+
 ### Helm
 
 Add the plugin to the `global.dynamic.plugins` array in your `values.yaml`:


### PR DESCRIPTION
## Summary
- Promotes the one outstanding commit on \`develop\` (\`affa0c1\`) into production.
- That commit is the discoverability pointer added to \`devportal/plugins/adding.md\` linking the \`integrity:\` field to the existing hash-generation section in \`development/loading.md\`.
- Triggers the MCP republish workflow (\`publish-mcp.yml\` fires on push to \`main\`), so the next MCP snapshot will reflect the fix.

## Why now
This is the last residual gap from round-3 validation. After this merge, the team announcement (docs + MCP + Claude Code as the canonical resource for DevPortal questions) can go out grounded on a snapshot that no longer reports P10 as a gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)