### PR TITLE
fix(docs): resolve all broken links + enforce broken-link check in CI

### DIFF
--- a/admin-ui/Settings/03-git-providers.md
+++ b/admin-ui/Settings/03-git-providers.md
@@ -46,7 +46,7 @@ This guide explains how to integrate your **DevPortal** with a Git provider (suc
 :::warning
 
 For the full integration and operation of the DevPortal with GitHub, you should create and configure your authentication application(GitHub Oauth) and add the host that has been provided to you in the EC2 console.
-**To configure your GitHub Oauth integration, please follow this [step-by-step guide](/devportal/installation-guide/production-setup#create-a-new-github-oauth-app )**
+**To configure your GitHub Oauth integration, please follow this [step-by-step guide](/devportal/integrations/GitHub/github-auth#step-1-create-an-oauth-app)**
 
 :::
 

--- a/devportal/installation-guide/FAQs.md
+++ b/devportal/installation-guide/FAQs.md
@@ -34,7 +34,7 @@ Common causes:
 
 ### I set a key in `app-config.local.yaml` but it has no effect
 
-Config files are merged in a 7-layer order. Your `app-config.local.yaml` is layer 5, but plugin-generated config (`dynamic-plugins-root/app-config.dynamic-plugins.yaml`) is layer 6 and loads after it. A plugin's `pluginConfig` block in `dynamic-plugins.yaml` can override keys from your `local.yaml`. See [Custom Configuration](./docker-local/custom-config) for the full merge order.
+Config files are merged in a 7-layer order. Your `app-config.local.yaml` is layer 5, but plugin-generated config (`dynamic-plugins-root/app-config.dynamic-plugins.yaml`) is layer 6 and loads after it. A plugin's `pluginConfig` block in `dynamic-plugins.yaml` can override keys from your `local.yaml`. See [Custom Configuration](./docker-local/custom-config.md) for the full merge order.
 
 ---
 
@@ -110,7 +110,7 @@ plugins:
     disabled: false
 ```
 
-See [Dynamic Plugins](./docker-local/custom-plugins) for details.
+See [Dynamic Plugins](./docker-local/custom-plugins.md) for details.
 
 ### My `dynamic-plugins.yaml` disables all plugins unexpectedly
 

--- a/devportal/installation-guide/docker-local/custom-catalog.md
+++ b/devportal/installation-guide/docker-local/custom-catalog.md
@@ -209,7 +209,7 @@ catalog:
 
 ## Replacing vs adding to the demo catalog
 
-The default DevPortal image ships with demo entities registered via `/app/examples/` in `app-config.production.yaml` (see [Docker Run — What's in the demo catalog](./intro#whats-in-the-demo-catalog)). Backstage merges `catalog.locations[]` **additively** across config layers, so understanding the consequence matters:
+The default DevPortal image ships with demo entities registered via `/app/examples/` in `app-config.production.yaml` (see [Docker Run — What's in the demo catalog](./intro.md#whats-in-the-demo-catalog)). Backstage merges `catalog.locations[]` **additively** across config layers, so understanding the consequence matters:
 
 **Adding alongside the demo (the common case):** Anything you put in `app-config.local.yaml` under `catalog.locations[]` is appended to the demo locations. Both sets will appear in the portal. This is what every example in this page does, and it's almost always what you want for a first contact.
 
@@ -234,6 +234,6 @@ Mounting your own `app-config.production.yaml` replaces the file entirely. Make 
 
 ## Next Steps
 
-- [Custom App Configuration](./custom-config)
-- [Configure Dynamic Plugins](./custom-plugins)
+- [Custom App Configuration](./custom-config.md)
+- [Configure Dynamic Plugins](./custom-plugins.md)
 - [Backstage Catalog Documentation](https://backstage.io/docs/features/software-catalog/)

--- a/devportal/installation-guide/docker-local/custom-config.md
+++ b/devportal/installation-guide/docker-local/custom-config.md
@@ -159,5 +159,5 @@ docker run --rm --name devportal -d \
 
 ## Next Steps
 
-- [Configure Dynamic Plugins](./custom-plugins)
-- [Add Custom Catalog](./custom-catalog)
+- [Configure Dynamic Plugins](./custom-plugins.md)
+- [Add Custom Catalog](./custom-catalog.md)

--- a/devportal/installation-guide/docker-local/intro.md
+++ b/devportal/installation-guide/docker-local/intro.md
@@ -78,7 +78,7 @@ Points to notice:
 
 - "Guest" authentication enabled as an admin user ("user:default/admin", "group:default/admins", "role:default/admin" with all permissions granted).
 - The catalog is populated with built-in demo entities (see [What's in the demo catalog](#whats-in-the-demo-catalog) below).
-- The container loads several config files in a defined precedence order. Your custom file at `/app/app-config.local.yaml` overrides the base and profile defaults. See [Custom Configuration](./custom-config) for the full merge order.
+- The container loads several config files in a defined precedence order. Your custom file at `/app/app-config.local.yaml` overrides the base and profile defaults. See [Custom Configuration](./custom-config.md) for the full merge order.
 - There are many plugins already bundled in the container image, ready to be enabled. You can mount the `/app/dynamic-plugins.yaml` plugin file to enable those you want to use.
 
 We will talk more about these subjects later on, but understand there are many possible ways to extend and configure DevPortal container without rebuilding it (or making a derived image).
@@ -119,13 +119,13 @@ The three demo Templates appear in the **Create** tab but will fail at execution
 - **Adding your own entities alongside the demo:** mount your own `catalog-info.yaml` and add it as a location in `app-config.local.yaml`. Both sets will appear.
 - **Fully removing the demo entities:** mount a replacement `app-config.production.yaml` that omits the `/app/examples/` entries. You must preserve all the other settings from the original (baseUrl, CORS, auth, RBAC paths, etc.) — only do this when you intentionally want a clean catalog.
 
-See [Custom Catalog](./custom-catalog#replacing-vs-adding-to-the-demo-catalog) for the concrete YAML.
+See [Custom Catalog](./custom-catalog.md#replacing-vs-adding-to-the-demo-catalog) for the concrete YAML.
 
 ## Next Steps
 
 Now that you have DevPortal running, you can customize it:
 
-- **[Quick Setup with Profiles](./profiles)**: Use `VEECODE_PROFILE` for quick GitHub, GitLab, or Azure DevOps integration
-- **[Custom Configuration](./custom-config)**: Mount custom `app-config.local.yaml` to configure integrations, authentication, and more
-- **[Dynamic Plugins](./custom-plugins)**: Enable, disable, and configure plugins using `dynamic-plugins.yaml`
-- **[Custom Catalog](./custom-catalog)**: Add your own components, APIs, and resources to the catalog
+- **[Quick Setup with Profiles](./profiles.md)**: Use `VEECODE_PROFILE` for quick GitHub, GitLab, or Azure DevOps integration
+- **[Custom Configuration](./custom-config.md)**: Mount custom `app-config.local.yaml` to configure integrations, authentication, and more
+- **[Dynamic Plugins](./custom-plugins.md)**: Enable, disable, and configure plugins using `dynamic-plugins.yaml`
+- **[Custom Catalog](./custom-catalog.md)**: Add your own components, APIs, and resources to the catalog

--- a/devportal/installation-guide/docker-local/profiles.md
+++ b/devportal/installation-guide/docker-local/profiles.md
@@ -491,6 +491,6 @@ docker run ... -e CATALOG_INDEX_REFRESH=true veecode/devportal:latest
 
 ## Next Steps
 
-- [Custom Configuration](./custom-config) for advanced customization
-- [Dynamic Plugins](./custom-plugins) to enable additional features
-- [Custom Catalog](./custom-catalog) to add manual catalog entries
+- [Custom Configuration](./custom-config.md) for advanced customization
+- [Dynamic Plugins](./custom-plugins.md) to enable additional features
+- [Custom Catalog](./custom-catalog.md) to add manual catalog entries

--- a/devportal/installation-guide/production-setup/production-setup.md
+++ b/devportal/installation-guide/production-setup/production-setup.md
@@ -31,4 +31,4 @@ Use this guide when you need a persistent, team-accessible DevPortal instance â€
 | **Image** | `veecode/devportal:1.4.5` |
 | **ArtifactHub** | [veecode-platform-next/veecode-devportal](https://artifacthub.io/packages/helm/veecode-platform-next/veecode-devportal) |
 
-See [Understand the Helm Chart](../understand-chart) for a detailed breakdown of chart values.
+See [Understand the Helm Chart](../understand-chart.md) for a detailed breakdown of chart values.

--- a/devportal/installation-guide/production-setup/setup.md
+++ b/devportal/installation-guide/production-setup/setup.md
@@ -110,7 +110,7 @@ kubectl create secret generic devportal-secrets \
 
 ## Step 3: Create your `values.yaml`
 
-The chart name is `veecode-devportal` from the `veecode-devportal` Helm repository. See [Understand the Helm Chart](../understand-chart) for a full reference of available keys.
+The chart name is `veecode-devportal` from the `veecode-devportal` Helm repository. See [Understand the Helm Chart](../understand-chart.md) for a full reference of available keys.
 
 <Tabs groupId="providers">
 <TabItem value="github" label="GitHub">
@@ -258,6 +258,6 @@ kubectl rollout status deployment/veecode-devportal-backstage -n platform
 
 - Configure additional integrations and plugins — see the [Auth & Integrations](/devportal/integrations) section.
 - Review RBAC roles (`role:default/admin`, `role:default/developer`, `role:default/viewer`) and assign them to users.
-- For a deeper explanation of chart keys, see [Understand the Helm Chart](../understand-chart) or the [chart page on ArtifactHub](https://artifacthub.io/packages/helm/veecode-platform-next/veecode-devportal).
+- For a deeper explanation of chart keys, see [Understand the Helm Chart](../understand-chart.md) or the [chart page on ArtifactHub](https://artifacthub.io/packages/helm/veecode-platform-next/veecode-devportal).
 
 If you encounter issues, reach out via [support](https://platform.vee.codes/contact-us/) or join the [community](https://github.com/orgs/veecode-platform/discussions).

--- a/devportal/installation-guide/simple-setup/check-prerequisites.md
+++ b/devportal/installation-guide/simple-setup/check-prerequisites.md
@@ -12,4 +12,4 @@ Use this checklist to ensure you're ready to install the DevPortal.
 - [ ] Git provider account ready (GitHub or GitLab)
 - [ ] Optional: Ingress controller (nginx or kong) installed in the cluster
 
-If you already have them ready, you can skip to the next section named [Create or choose a target organization/group](./target-organization-group).
+If you already have them ready, you can skip to the next section named [Create or choose a target organization/group](./target-organization-group.md).

--- a/devportal/installation-guide/simple-setup/create-values-file.md
+++ b/devportal/installation-guide/simple-setup/create-values-file.md
@@ -49,4 +49,4 @@ To enable authentication and full Git provider integration (GitHub, GitLab, etc.
 
 ### About the Helm chart
 
-Please check [Understand the Helm Chart](../understand-chart) for more information on the chart structure and available settings. You can also check the chart page on [ArtifactHub](https://artifacthub.io/packages/helm/veecode-platform-next/veecode-devportal).
+Please check [Understand the Helm Chart](../understand-chart.md) for more information on the chart structure and available settings. You can also check the chart page on [ArtifactHub](https://artifacthub.io/packages/helm/veecode-platform-next/veecode-devportal).

--- a/devportal/installation-guide/simple-setup/simple-setup.md
+++ b/devportal/installation-guide/simple-setup/simple-setup.md
@@ -4,7 +4,7 @@ sidebar_label: Simple setup
 title: Simple setup
 ---
 
-While in the previous [Local Setup](../vkdr-local/vkdr-setup) section we have installed VeeCode DevPortal on a local temporary cluster, in this guide we will install it on a real live Kubernetes cluster in the simplest possible way, so other people may try it.
+While in the previous [Local Setup](../vkdr-local/vkdr-setup.md) section we have installed VeeCode DevPortal on a local temporary cluster, in this guide we will install it on a real live Kubernetes cluster in the simplest possible way, so other people may try it.
 
 This setup is a little more elaborated:
 
@@ -15,9 +15,9 @@ This setup is a little more elaborated:
 
 These steps should suffice for smaller teams for testing purposes or even for production use.
 
-- [Check prerequisites and accounts](./check-prerequisites)
-- [Create or choose a target organization/group](./target-organization-group)
-- [Choose a base template catalog](./choose-template-catalog)
-- [Create a "values" file](./create-values-file)
-- [Deploy VeeCode DevPortal](./deploy-devportal)
-- [Configure Git provider integration](./configure-git-integrations)
+- [Check prerequisites and accounts](./check-prerequisites.md)
+- [Create or choose a target organization/group](./target-organization-group.md)
+- [Choose a base template catalog](./choose-template-catalog.md)
+- [Create a "values" file](./create-values-file.md)
+- [Deploy VeeCode DevPortal](./deploy-devportal.md)
+- [Configure Git provider integration](./configure-git-integrations.md)

--- a/devportal/intro.md
+++ b/devportal/intro.md
@@ -24,7 +24,7 @@ VeeCode DevPortal is a Backstage distro that provides a production-grade portal 
 - It is an API showcase and governance tool for both developers and business partners
 - It simplifies DevOps adoption and scaling, removing cognitive load from average teams
 
-If you want to understand **why** this portal matters before diving into setup — the reasoning behind golden paths, self-service design, and developer autonomy — start with [Platform Concepts](/platform/concepts). If you're here to install and configure, continue below.
+If you want to understand **why** this portal matters before diving into setup — the reasoning behind golden paths, self-service design, and developer autonomy — start with [Platform Concepts](/platform/concepts/portal-composition). If you're here to install and configure, continue below.
 
 <div className={style.wrapper}>
 
@@ -32,7 +32,7 @@ If you want to understand **why** this portal matters before diving into setup �
 
 <DocCard title="💡 Concepts" link="/devportal/concepts/catalog" style={style}>Understand the core concepts and terminology related to the Developer Portal.</DocCard>
 
-<DocCard title="🧩 Plugins" link="/devportal/plugins/plugins" style={style}>Enable and configure plugins to extend DevPortal with Day-2 capabilities.</DocCard>
+<DocCard title="🧩 Plugins" link="/devportal/plugins" style={style}>Enable and configure plugins to extend DevPortal with Day-2 capabilities.</DocCard>
 
 <DocCard title="📍 Troubleshooting" link="/devportal/troubleshooting" style={style}>Find solutions to common issues and learn how to report errors.</DocCard>
 

--- a/devportal/plugins/adding.md
+++ b/devportal/plugins/adding.md
@@ -151,7 +151,7 @@ The same disambiguation pattern applies whenever you see plugins from `@backstag
 The README of `devportal-plugin-export-overlays` is partially stale — it mentions `ghcr.io/veecode-platform/...` as the registry and a `bs_<version>__<plugin-version>` tag format. The actual published artifacts use `quay.io/veecode/...` with `bs_<version>` only. Trust the `dynamicArtifact` field in each plugin's `metadata/<plugin>.yaml` — that's what the CI pipeline writes and what the Marketplace reads.
 :::
 
-For a complete list of bundled (preloaded) plugins that do not require an OCI reference, see [Bundled Plugins](./bundled).
+For a complete list of bundled (preloaded) plugins that do not require an OCI reference, see [Bundled Plugins](./bundled/index.md).
 
 ### VKDR (local setup)
 
@@ -185,7 +185,7 @@ global:
 :::note `integrity:` is npm-only — and required
 The `integrity:` field is **required for remote npm packages** (unless `SKIP_INTEGRITY_CHECK=true` is set). It is **not used** for OCI packages (`oci://...`, validated by digest comparison) or local paths (`./dynamic-plugins/dist/...`, pre-bundled in the image).
 
-To generate the `sha512-<base64>` string, see [Generating the integrity hash](./development/loading#generating-the-integrity-hash) — covers both `npm view <pkg>@<ver> dist.integrity` (preferred) and an `openssl`-based fallback.
+To generate the `sha512-<base64>` string, see [Generating the integrity hash](./development/loading.md#generating-the-integrity-hash) — covers both `npm view <pkg>@<ver> dist.integrity` (preferred) and an `openssl`-based fallback.
 :::
 
 ### Helm

--- a/devportal/plugins/bundled/global-header.md
+++ b/devportal/plugins/bundled/global-header.md
@@ -46,4 +46,4 @@ The header mounts at `application/header` and adds the following components to t
 
 ## Customization
 
-Additional components can be injected into the header by adding entries to the `global.header/component` mount point in `dynamic-plugins.yaml`. See [Wiring a Frontend Plugin](../development/wiring) for the configuration syntax.
+Additional components can be injected into the header by adding entries to the `global.header/component` mount point in `dynamic-plugins.yaml`. See [Wiring a Frontend Plugin](../development/wiring.md) for the configuration syntax.

--- a/devportal/plugins/bundled/index.md
+++ b/devportal/plugins/bundled/index.md
@@ -18,13 +18,13 @@ Think of this catalog in terms of capability layers, not a flat install list. Th
 
 | Plugin | Package | What it does |
 |---|---|---|
-| [RBAC](./rbac) | `backstage-community-plugin-rbac` | Role-based access control UI at `/rbac` |
-| [Homepage](./homepage) | `veecode-platform-plugin-veecode-homepage-dynamic` | Customizable landing page at `/` |
-| [Global Header](./global-header) | `veecode-platform-plugin-veecode-global-header-dynamic` | Unified top navigation bar (search, notifications, profile) |
-| [Tech Radar](./tech-radar) | `backstage-community-plugin-tech-radar-dynamic` + `backstage-community-plugin-tech-radar-backend-dynamic` | Technology adoption radar at `/tech-radar` |
-| [About](./about) | `veecode-platform-backstage-plugin-about-dynamic` + `veecode-platform-backstage-plugin-about-backend-dynamic` | DevPortal version and instance info at `/about` |
-| [Marketplace](./marketplace) | `devportal-marketplace-frontend-dynamic` + `devportal-marketplace-backend-dynamic-dynamic` | In-portal plugin discovery and enable/disable UI at `/marketplace` |
-| [Pending Changes](./pending-changes) | `devportal-pending-changes-dynamic` | Header badge indicating pending restart when plugins are enabled/disabled via Marketplace |
+| [RBAC](./rbac.md) | `backstage-community-plugin-rbac` | Role-based access control UI at `/rbac` |
+| [Homepage](./homepage.md) | `veecode-platform-plugin-veecode-homepage-dynamic` | Customizable landing page at `/` |
+| [Global Header](./global-header.md) | `veecode-platform-plugin-veecode-global-header-dynamic` | Unified top navigation bar (search, notifications, profile) |
+| [Tech Radar](./tech-radar.md) | `backstage-community-plugin-tech-radar-dynamic` + `backstage-community-plugin-tech-radar-backend-dynamic` | Technology adoption radar at `/tech-radar` |
+| [About](./about.md) | `veecode-platform-backstage-plugin-about-dynamic` + `veecode-platform-backstage-plugin-about-backend-dynamic` | DevPortal version and instance info at `/about` |
+| [Marketplace](./marketplace.md) | `devportal-marketplace-frontend-dynamic` + `devportal-marketplace-backend-dynamic-dynamic` | In-portal plugin discovery and enable/disable UI at `/marketplace` |
+| [Pending Changes](./pending-changes.md) | `devportal-pending-changes-dynamic` | Header badge indicating pending restart when plugins are enabled/disabled via Marketplace |
 | Catalog Extensions Module | `red-hat-developer-hub-backstage-plugin-catalog-backend-module-extensions` | Registers Extension/Package/Collection entity kinds; reads `extensions-install.yaml` |
 
 ---
@@ -33,12 +33,12 @@ Think of this catalog in terms of capability layers, not a flat install list. Th
 
 | Plugin | Package | What it does |
 |---|---|---|
-| [Kubernetes](../kubernetes) | `backstage-plugin-kubernetes-dynamic` | Kubernetes workload viewer on entity pages |
-| [GitHub Actions](./github-actions) | `backstage-community-plugin-github-actions-dynamic` | GitHub Actions run history on entity CI tab |
-| [GitHub Workflows](../GitHubWorkflows) | `veecode-platform-backstage-plugin-github-workflows-dynamic` + backend | Manual workflow trigger cards on entity overview |
-| [Azure DevOps](./azure-devops) | `backstage-community-plugin-azure-devops-dynamic` | Azure Pipelines and Pull Requests on entity pages |
-| [Jenkins](./jenkins) | `backstage-community-plugin-jenkins` + `backstage-community-plugin-jenkins-backend-dynamic` | Jenkins build status on entity CI tab |
-| [SonarQube](../Sonar) | `backstage-community-plugin-sonarqube` + `backstage-community-plugin-sonarqube-backend-dynamic` | Code quality metrics on entity overview and Code Quality tab |
+| [Kubernetes](../kubernetes.md) | `backstage-plugin-kubernetes-dynamic` | Kubernetes workload viewer on entity pages |
+| [GitHub Actions](./github-actions.md) | `backstage-community-plugin-github-actions-dynamic` | GitHub Actions run history on entity CI tab |
+| [GitHub Workflows](../GitHubWorkflows.md) | `veecode-platform-backstage-plugin-github-workflows-dynamic` + backend | Manual workflow trigger cards on entity overview |
+| [Azure DevOps](./azure-devops.md) | `backstage-community-plugin-azure-devops-dynamic` | Azure Pipelines and Pull Requests on entity pages |
+| [Jenkins](./jenkins.md) | `backstage-community-plugin-jenkins` + `backstage-community-plugin-jenkins-backend-dynamic` | Jenkins build status on entity CI tab |
+| [SonarQube](../Sonar.md) | `backstage-community-plugin-sonarqube` + `backstage-community-plugin-sonarqube-backend-dynamic` | Code quality metrics on entity overview and Code Quality tab |
 | Security Insights | `roadiehq-backstage-plugin-security-insights-dynamic` | GitHub Dependabot alerts and security advisories |
 | GitHub Insights | `roadiehq-backstage-plugin-github-insights-dynamic` | GitHub code insights on entity pages |
 | Global FAB | `red-hat-developer-hub-backstage-plugin-global-floating-action-button-dynamic` | Configurable floating action button |
@@ -47,7 +47,7 @@ Think of this catalog in terms of capability layers, not a flat install list. Th
 
 ## OCI-only plugins (not in distro image, enable via dynamic-plugins.yaml)
 
-These must be downloaded at startup from `quay.io/veecode`. See [Adding Plugins](../adding) for configuration details.
+These must be downloaded at startup from `quay.io/veecode`. See [Adding Plugins](../adding.md) for configuration details.
 
 | Plugin | OCI Reference |
 |---|---|
@@ -61,4 +61,4 @@ These must be downloaded at startup from `quay.io/veecode`. See [Adding Plugins]
 
 ---
 
-For plugins not listed here (Grafana, Vault, Tech Insights, and others), see [Finding Plugins](../finding) and [Adding Plugins](../adding).
+For plugins not listed here (Grafana, Vault, Tech Insights, and others), see [Finding Plugins](../finding.md) and [Adding Plugins](../adding.md).

--- a/devportal/plugins/bundled/rbac.md
+++ b/devportal/plugins/bundled/rbac.md
@@ -60,4 +60,4 @@ permission:
       - kubernetes
 ```
 
-See [Permissions and RBAC](../../rbac/permissions) for full configuration details.
+See [Permissions and RBAC](../../rbac/permissions.md) for full configuration details.

--- a/devportal/plugins/cicd.md
+++ b/devportal/plugins/cicd.md
@@ -8,7 +8,7 @@ title: CI/CD Plugins
 
 The problem CI/CD plugins solve is the same across every platform: the service is registered in the portal, but its pipeline lives in GitHub Actions, GitLab, Jenkins, or Azure DevOps. Developers context-switch to check builds, find failures, and trigger runs. Each CI/CD plugin closes that gap for one platform by surfacing build status and triggers on the entity page itself — the service and its pipeline become one view.
 
-This is the [Application Lifecycle](/platform/capabilities) capability layer in practice. Pick the plugin that matches the platform your team uses; the activation pattern is the same for all of them.
+This is the [Application Lifecycle](/platform/capabilities/platform-capabilities) capability layer in practice. Pick the plugin that matches the platform your team uses; the activation pattern is the same for all of them.
 
 DevPortal ships several separate CI/CD plugins, each integrating with a specific CI/CD platform. There is no single "CI/CD Plugin" — each platform has its own bundled plugin that must be enabled individually.
 
@@ -20,11 +20,11 @@ All CI/CD plugins described here are **preloaded in the DevPortal image and disa
 
 | Plugin | Platform | Package |
 |---|---|---|
-| [GitHub Actions](./bundled/github-actions) | GitHub Actions workflow runs | `backstage-community-plugin-github-actions-dynamic` |
-| [GitHub Workflows](./GitHubWorkflows) | Manual GitHub workflow trigger + cards | `veecode-platform-backstage-plugin-github-workflows-dynamic` |
-| [Jenkins](./bundled/jenkins) | Jenkins build status | `backstage-community-plugin-jenkins` + backend |
-| [Azure DevOps](./bundled/azure-devops) | Azure Pipelines + Pull Requests | `backstage-community-plugin-azure-devops-dynamic` |
-| [GitLab Pipelines](./GitLabPipelines) | GitLab CI pipeline trigger and status | OCI: `oci://quay.io/veecode/gitlab:bs_1.48.4!immobiliarelabs-backstage-plugin-gitlab` |
+| [GitHub Actions](./bundled/github-actions.md) | GitHub Actions workflow runs | `backstage-community-plugin-github-actions-dynamic` |
+| [GitHub Workflows](./GitHubWorkflows.md) | Manual GitHub workflow trigger + cards | `veecode-platform-backstage-plugin-github-workflows-dynamic` |
+| [Jenkins](./bundled/jenkins.md) | Jenkins build status | `backstage-community-plugin-jenkins` + backend |
+| [Azure DevOps](./bundled/azure-devops.md) | Azure Pipelines + Pull Requests | `backstage-community-plugin-azure-devops-dynamic` |
+| [GitLab Pipelines](./GitLabPipelines.md) | GitLab CI pipeline trigger and status | OCI: `oci://quay.io/veecode/gitlab:bs_1.48.4!immobiliarelabs-backstage-plugin-gitlab` |
 
 ---
 

--- a/devportal/plugins/development/wiring.md
+++ b/devportal/plugins/development/wiring.md
@@ -34,7 +34,7 @@ global:
 
 ## Testing with VKDR
 
-Our [local DevPortal setup](../../installation-guide/vkdr-local/vkdr-setup) using `vkdr` can be used to validate locally the wiring of a dynamic frontend plugin.
+Our [local DevPortal setup](../../installation-guide/vkdr-local/vkdr-setup.md) using `vkdr` can be used to validate locally the wiring of a dynamic frontend plugin.
 
 ### Steps
 
@@ -43,7 +43,7 @@ What you need:
 - A local npm registry (run [Verdaccio](https://verdaccio.org/) at local port 4873)
 - Publish the frontend plugin to Verdaccio (as described [here](/devportal/plugins/development/packaging#publish-a-dynamic-plugin))
 - Obtain the SHA integrity signature of the published plugin
-- A local `vkdr` cluster with DevPortal properly installed - check the [local DevPortal setup](../../installation-guide/vkdr-local/vkdr-setup) guide for more info.
+- A local `vkdr` cluster with DevPortal properly installed - check the [local DevPortal setup](../../installation-guide/vkdr-local/vkdr-setup.md) guide for more info.
 
 ### Verdaccio
 

--- a/devportal/plugins/finding.md
+++ b/devportal/plugins/finding.md
@@ -14,7 +14,7 @@ The Marketplace shows:
 - All bundled plugins (preloaded in the image, ready to enable)
 - OCI-published plugins available for download at startup
 
-See [Bundled Plugins](./bundled) for a complete list of what ships with DevPortal.
+See [Bundled Plugins](./bundled/index.md) for a complete list of what ships with DevPortal.
 
 ---
 

--- a/devportal/plugins/grafana.md
+++ b/devportal/plugins/grafana.md
@@ -17,7 +17,7 @@ Your options:
 
 1. **Reference the npm package directly** — if upstream Roadie publishes a dynamic build of this plugin, you can use `package: '@roadiehq/backstage-plugin-grafana'` in `dynamic-plugins.yaml`. Confirm upstream has a `-dynamic` artifact before relying on this.
 2. **Fork [`devportal-plugin-export-overlays`](https://github.com/veecode-platform/devportal-plugin-export-overlays)** and add the plugin to a workspace yourself, then publish your own OCI artifact.
-3. **Use an alternative** — for ready-to-use observability/quality plugins that VeeCode publishes today, see [Tech Insights](./bundled), [SonarQube](./Sonar), or the `kiali` workspace for service-mesh observability.
+3. **Use an alternative** — for ready-to-use observability/quality plugins that VeeCode publishes today, see [Tech Insights](./bundled/index.md), [SonarQube](./Sonar.md), or the `kiali` workspace for service-mesh observability.
 
 The configuration below shows the composition contract (annotation + backend config) regardless of which installation path you choose.
 :::
@@ -53,7 +53,7 @@ plugins:
                       - isGrafanaAvailable
 ```
 
-Replace `<workspace>` and `<tag>` with the values that match your instance. See [Adding Plugins](./adding) for details on the OCI artifact format.
+Replace `<workspace>` and `<tag>` with the values that match your instance. See [Adding Plugins](./adding.md) for details on the OCI artifact format.
 
 ---
 
@@ -88,4 +88,4 @@ metadata:
 ## References
 
 - [Roadie Grafana plugin on GitHub](https://github.com/RoadieHQ/roadie-backstage-plugins/tree/main/plugins/frontend/backstage-plugin-grafana)
-- [Adding Plugins to DevPortal](./adding)
+- [Adding Plugins to DevPortal](./adding.md)

--- a/devportal/plugins/plugins.md
+++ b/devportal/plugins/plugins.md
@@ -91,7 +91,7 @@ Examples of always-active preInstalled plugins: VeeCode Homepage, Global Header,
 
 Examples of bundled-but-disabled plugins: Kubernetes, GitHub Actions, Azure DevOps, Jenkins, SonarQube, GitHub Workflows.
 
-For the complete list with package names and enable instructions, see the [Bundled Plugin Catalog](./bundled).
+For the complete list with package names and enable instructions, see the [Bundled Plugin Catalog](./bundled/index.md).
 
 ### Downloaded plugins
 

--- a/devportal/plugins/vault.md
+++ b/devportal/plugins/vault.md
@@ -24,7 +24,7 @@ Search for "Vault" in the DevPortal Marketplace and click **Enable**.
 
 ### Via `dynamic-plugins.yaml`
 
-Check the [Marketplace](../plugins/finding) or the [Backstage Plugin Registry](https://backstage.io/plugins) for the current OCI reference and workspace tag that matches your DevPortal's Backstage version.
+Check the [Marketplace](./finding.md) or the [Backstage Plugin Registry](https://backstage.io/plugins) for the current OCI reference and workspace tag that matches your DevPortal's Backstage version.
 
 A typical entry looks like:
 
@@ -47,7 +47,7 @@ plugins:
                       - isVaultAvailable
 ```
 
-Replace `<workspace>` and `<tag>` with the values that match your instance. See [Adding Plugins](./adding) for details on the OCI artifact format.
+Replace `<workspace>` and `<tag>` with the values that match your instance. See [Adding Plugins](./adding.md) for details on the OCI artifact format.
 
 ---
 
@@ -88,4 +88,4 @@ The entity card only renders when this annotation is present.
 
 - [Backstage Community Vault plugin](https://github.com/backstage/community-plugins/tree/main/workspaces/vault)
 - [HashiCorp Vault documentation](https://developer.hashicorp.com/vault/docs)
-- [Adding Plugins to DevPortal](./adding)
+- [Adding Plugins to DevPortal](./adding.md)

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -12,8 +12,9 @@ const config = {
   tagline: "Access the comprehensive documentation for VeeCode Platform, covering the DevPortal and Admin-UI. Learn how to effectively use these powerful tools to build and deploy your applications with ease.",
   url: "https://docs.platform.vee.codes/",
   baseUrl: "/",
-  onBrokenLinks: "ignore",
-  onBrokenMarkdownLinks: "warn",
+  onBrokenLinks: "throw",
+  onBrokenMarkdownLinks: "throw",
+  onBrokenAnchors: "throw",
   favicon: "img/favicon.ico",
   organizationName: "veecode-platform", // Usually your GitHub org/user name.
   projectName: "VeeCode Platform Services", // Usually your repo name.

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@veecode-platform/docs-mcp",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "MCP server exposing VeeCode Platform documentation to CLI agents",
   "license": "Apache-2.0",
   "type": "module",

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@veecode-platform/docs-mcp",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "description": "MCP server exposing VeeCode Platform documentation to CLI agents",
   "license": "Apache-2.0",
   "type": "module",

--- a/platform/concepts/blueprints.md
+++ b/platform/concepts/blueprints.md
@@ -10,7 +10,7 @@ title: Blueprints & Reference Implementations
 
 ## What is a Blueprint?
 
-While a [Golden Path](./golden-paths) focuses on the *workflow* and *automation* to get a specific service to production, a **Blueprint** focuses on the *architecture* and *design* of a solution. It answers questions like:
+While a [Golden Path](./golden-paths.md) focuses on the *workflow* and *automation* to get a specific service to production, a **Blueprint** focuses on the *architecture* and *design* of a solution. It answers questions like:
 
 - "How do we build a microservices architecture?"
 - "What is the standard pattern for event-driven systems?"

--- a/platform/concepts/platform-basic.md
+++ b/platform/concepts/platform-basic.md
@@ -12,7 +12,7 @@ An **Internal Developer Platform (IDP)** is a curated set of tools, services, an
 
 ## Core Definition
 
-An Internal Developer Platform (IDP) is fundamentally about reducing cognitive load on stream-aligned product teams (as defined in [Team Topologies](../references/team-topologies)) by providing the thinnest viable platform. This allows teams to **focus on business logic and outcomes**, instead of wrestling with infrastructure and operational concerns.
+An Internal Developer Platform (IDP) is fundamentally about reducing cognitive load on stream-aligned product teams (as defined in [Team Topologies](../references/team-topologies.md)) by providing the thinnest viable platform. This allows teams to **focus on business logic and outcomes**, instead of wrestling with infrastructure and operational concerns.
 
 The Platform serves as a digital foundation that:
 
@@ -93,6 +93,6 @@ Reference implementations and architectural patterns for building complex system
 
 ## Conclusion
 
-An Internal Developer Platform is not just a collection of tools—it's a **strategic capability** that enables organizations to achieve the fast flow of change essential for competitive advantage in the digital economy. By applying [Team Topologies](../references/team-topologies) principles and cloud native patterns, an IDP becomes the foundation that allows development teams to focus on what matters most: delivering value to customers.
+An Internal Developer Platform is not just a collection of tools—it's a **strategic capability** that enables organizations to achieve the fast flow of change essential for competitive advantage in the digital economy. By applying [Team Topologies](../references/team-topologies.md) principles and cloud native patterns, an IDP becomes the foundation that allows development teams to focus on what matters most: delivering value to customers.
 
 The key to success lies in maintaining the balance between providing powerful capabilities while keeping cognitive load low, treating the platform as a product, and continuously evolving based on the needs of stream-aligned teams.

--- a/platform/how-to/build-your-own-platform.md
+++ b/platform/how-to/build-your-own-platform.md
@@ -46,11 +46,11 @@ Most “platform work” is curating and integrating the tools you already run, 
 5. **Measure impact**: Track DORA and adoption metrics from day one. Remember: platform value appears in downstream metrics, not as a plain platform output. **Learn to capture the ROI of your platform to make ROI visible**.
 
 ## How to Prove It Works
-- Use outcome metrics that matter to the business. See: [Success Metrics](../capabilities/success-metrics).
-- Anchor platform scope in team cognition and interactions. See: [Team Topologies](../references/team-topologies).
-- Ground your architecture and operating model in modern practices. See: [Cloud Native Transformation](../references/cloud-native-transformation).
+- Use outcome metrics that matter to the business. See: [Success Metrics](../capabilities/success-metrics.md).
+- Anchor platform scope in team cognition and interactions. See: [Team Topologies](../references/team-topologies.md).
+- Ground your architecture and operating model in modern practices. See: [Cloud Native Transformation](../references/cloud-native-transformation.md).
 
 ## Further Reading
-- [What is a Developer Platform](../concepts/platform-basic)
-- [Cloud Native Transformation](../references/cloud-native-transformation)
-- [Team Topologies](../references/team-topologies)
+- [What is a Developer Platform](../concepts/platform-basic.md)
+- [Cloud Native Transformation](../references/cloud-native-transformation.md)
+- [Team Topologies](../references/team-topologies.md)

--- a/platform/how-to/index.md
+++ b/platform/how-to/index.md
@@ -15,9 +15,9 @@ Practical, step-by-step guides for building and evolving your Internal Developer
 - You’re looking for quick wins that move DORA and adoption metrics in the right direction.
 
 ## Start here
-- [Why You Will Build a Platform (and What That Really Means)](./build-your-own-platform)
+- [Why You Will Build a Platform (and What That Really Means)](./build-your-own-platform.md)
 
 ## Related references
-- [Success Metrics](../capabilities/success-metrics)
-- [Team Topologies](../references/team-topologies)
-- [Cloud Native Transformation](../references/cloud-native-transformation)
+- [Success Metrics](../capabilities/success-metrics.md)
+- [Team Topologies](../references/team-topologies.md)
+- [Cloud Native Transformation](../references/cloud-native-transformation.md)

--- a/platform/intro.md
+++ b/platform/intro.md
@@ -15,6 +15,6 @@ If you're looking for installation or configuration instructions, that's in [Dev
 - **[Composing a Portal](/platform/concepts/portal-composition)** — How plugins, catalog, and annotations compose into an operational hub; the three-layer model and Day-0/1/2 progression
 - **[Golden Paths](/platform/concepts/golden-paths)** — Why opinionated paths reduce cognitive load and how Software Templates realize them
 - **[Self-Service Design](/platform/concepts/self-service-design)** — What self-service means in practice and what it requires from the platform team
-- **[Capabilities](/platform/capabilities)** — The platform building blocks and how they compose
+- **[Capabilities](/platform/capabilities/platform-capabilities)** — The platform building blocks and how they compose
 
 VeeCode Platform is built on the principle of "batteries included but swappable": you can use it as-is or replace components to match your organization's tooling. The concepts here explain the reasoning behind default choices.

--- a/vkdr/database-commands/overview.md
+++ b/vkdr/database-commands/overview.md
@@ -14,7 +14,7 @@ Currently, `vkdr` supports PostgreSQL as a managed database service. PostgreSQL 
 
 ## Available Commands
 
-- **[postgres](./postgres)** - Manage PostgreSQL database instances
+- **[postgres](./postgres.md)** - Manage PostgreSQL database instances
 
 ## Quick Start
 

--- a/vkdr/devportal-commands/overview.md
+++ b/vkdr/devportal-commands/overview.md
@@ -27,7 +27,7 @@ vkdr kong install --default-ic
 
 ## Available Commands
 
-- **[devportal](./devportal)** - Install and manage VeeCode DevPortal
+- **[devportal](./devportal.md)** - Install and manage VeeCode DevPortal
 
 ## Quick Start
 

--- a/vkdr/ingress-commands/overview.md
+++ b/vkdr/ingress-commands/overview.md
@@ -14,10 +14,10 @@ When starting the `vkdr` cluster you have an option to enable Traefik as its def
 
 ## Available Ingress Controllers
 
-- **[nginx](./nginx)** - NGinx ingress controller (simple, widely used)
-- **[kong](./kong)** - Kong Gateway (API gateway with advanced features)
-- **[traefik](./traefik)** - Traefik ingress controller (modern, easy setup)
-- **[whoami](./whoami)** - Test service for verifying ingress
+- **[nginx](./nginx.md)** - NGinx ingress controller (simple, widely used)
+- **[kong](./kong.md)** - Kong Gateway (API gateway with advanced features)
+- **[traefik](./traefik.md)** - Traefik ingress controller (modern, easy setup)
+- **[whoami](./whoami.md)** - Test service for verifying ingress
 
 ## Quick Start Examples
 

--- a/vkdr/tools-commands/overview.md
+++ b/vkdr/tools-commands/overview.md
@@ -12,12 +12,12 @@ These commands are related to installing and managing supporting tools in your `
 
 ## Available Tools
 
-- **[keycloak](./keycloak)** - Identity and access management (IAM)
-- **[vault](./vault)** - HashiCorp Vault for secrets management
-- **[minio](./minio)** - S3-compatible object storage
-- **[eso](./eso)** - External Secrets Operator for syncing secrets
-- **[mirror](./mirror)** - Container image registry mirrors
-- **[openldap](./openldap)** - LDAP directory service
+- **[keycloak](./keycloak.md)** - Identity and access management (IAM)
+- **[vault](./vault.md)** - HashiCorp Vault for secrets management
+- **[minio](./minio.md)** - S3-compatible object storage
+- **[eso](./eso.md)** - External Secrets Operator for syncing secrets
+- **[mirror](./mirror.md)** - Container image registry mirrors
+- **[openldap](./openldap.md)** - LDAP directory service
 
 ## Quick Start
 


### PR DESCRIPTION
## Why
User reported 404s on links in production (\`/devportal/installation-guide/simple-setup\` and others). Investigation surfaced **two distinct broken-link classes** plus a config policy bug that allowed them to ship.

## Root cause (the policy bug)
\`docusaurus.config.js\` had \`onBrokenLinks: "ignore"\`. The build never failed on broken links, so any broken reference went straight to production silently. **This PR flips it to \`throw\`** (and also adds \`onBrokenAnchors: "throw"\`) so the next broken link breaks CI.

## What broke

### Class 1: Relative links without \`.md\` extension (89 occurrences, 28 files)
Docusaurus only resolves relative markdown links to absolute URLs **when the link includes \`.md\`**. Without it, the href passes through to HTML and the browser resolves it.

For pages where Docusaurus collapses the URL (file \`foo/foo.md\` is served at \`/foo\`, not \`/foo/foo\`), browser-side resolution of \`./bar\` or \`../sibling/baz\` lands on the wrong path. The reported \`simple-setup\` page is exactly this case:

| Source link | Browser-resolved (broken) | Should resolve to |
|---|---|---|
| \`./check-prerequisites\` | \`/devportal/installation-guide/check-prerequisites\` | \`/devportal/installation-guide/simple-setup/check-prerequisites\` |
| \`../vkdr-local/vkdr-setup\` | \`/devportal/vkdr-local/vkdr-setup\` | \`/devportal/installation-guide/vkdr-local/vkdr-setup\` |

**Fix:** automated sweep across all \`.md\` files; for every relative link whose target file exists, append \`.md\`. Docusaurus then resolves the link server-side at build time. 89/89 had a resolvable target — no manual triage needed.

### Class 2: Absolute links to non-existent paths (4 links + 1 anchor)
Surfaced by \`yarn build\` once \`onBrokenLinks\` was set to \`warn\`:
- \`/platform/concepts\` -> \`/platform/concepts/portal-composition\`
- \`/devportal/plugins/plugins\` -> \`/devportal/plugins\` (Docusaurus URL collapse — same as Class 1)
- \`/platform/capabilities\` (in two files) -> \`/platform/capabilities/platform-capabilities\`
- Anchor \`production-setup#create-a-new-github-oauth-app\` -> the actual OAuth-app setup section now lives in \`integrations/GitHub/github-auth\`; corrected to \`#step-1-create-an-oauth-app\`

## Verification
\`yarn build\` passes cleanly with \`onBrokenLinks: "throw"\` and \`onBrokenAnchors: "throw"\` (only deprecation warnings about config format remain).

## Test plan
- [ ] CI green
- [ ] After merge to main + deploy: spot-check \`/devportal/installation-guide/simple-setup\` and the six step-links work
- [ ] Spot-check the originally-reported \`Local Setup\` link in the same page goes to vkdr-setup

🤖 Generated with [Claude Code](https://claude.com/claude-code)