### PR TITLE
ci: add HTML link-crawler gate + fix legacy header broken link

### DIFF
--- a/.github/workflows/mcp-ci.yml
+++ b/.github/workflows/mcp-ci.yml
@@ -10,6 +10,10 @@ on:
       - platform/**
       - admin-ui/**
       - vkdr/**
+      - src/**
+      - docusaurus.config.js
+      - sidebars.js
+      - scripts/check-links.py
       - .github/workflows/mcp-ci.yml
 
 jobs:
@@ -27,6 +31,21 @@ jobs:
         run: yarn install --immutable
       - name: Build site (generates snapshot)
         run: yarn build
+      - name: Serve built site
+        run: |
+          nohup yarn serve --port 3001 > /tmp/docusaurus-serve.log 2>&1 &
+          for i in $(seq 1 30); do
+            if curl -fs http://localhost:3001/devportal/intro > /dev/null; then
+              echo "server ready"
+              exit 0
+            fi
+            sleep 2
+          done
+          echo "ERROR: server did not become ready within 60s"
+          cat /tmp/docusaurus-serve.log
+          exit 1
+      - name: Check for broken internal links
+        run: python3 scripts/check-links.py
       - name: Validate emitted snapshot
         run: |
           node -e "

--- a/scripts/check-links.py
+++ b/scripts/check-links.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+"""
+Exhaustive internal-link checker for the Docusaurus build.
+
+Walks every `index.html` under build/, extracts every internal `href`
+(absolute paths starting with `/`), and validates each one with a HEAD
+request against a locally-served build.
+
+Why this exists alongside Docusaurus `onBrokenLinks: throw`:
+- Docusaurus only validates links it knows are doc references (Markdown
+  links with `.md` extension, or absolute paths matching known doc routes).
+- Raw HTML hrefs in React components (e.g., custom headers/footers,
+  legacy pages) are passed through opaquely. The build never sees them.
+- This script catches that second class.
+
+Usage:
+    # in one shell: yarn build && yarn serve --port 3001
+    # in another:   python3 scripts/check-links.py
+
+Exit code 1 if any broken link is found.
+"""
+import os
+import re
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+from concurrent.futures import ThreadPoolExecutor, as_completed
+
+BUILD_DIR = os.environ.get("BUILD_DIR", "build")
+BASE_URL = os.environ.get("BASE_URL", "http://localhost:3001")
+TIMEOUT_SECONDS = 10
+PARALLELISM = 20
+
+HREF_RE = re.compile(r'href="([^"]+)"')
+
+
+def collect_pages(build_dir):
+    pages = []
+    for root, _, files in os.walk(build_dir):
+        for f in files:
+            if f == "index.html":
+                fpath = os.path.join(root, f)
+                url = fpath[len(build_dir):]
+                url = url[: -len("/index.html")]
+                pages.append((url or "/", fpath))
+    return pages
+
+
+def collect_internal_hrefs(pages):
+    links = {}
+    for url, fpath in pages:
+        with open(fpath, encoding="utf-8") as fh:
+            html = fh.read()
+        for href in HREF_RE.findall(html):
+            if not href.startswith("/"):
+                continue
+            clean = href.split("#")[0].split("?")[0]
+            if not clean:
+                continue
+            links.setdefault(clean, set()).add(url)
+    return links
+
+
+def check_one(path):
+    try:
+        encoded = urllib.parse.quote(path, safe="/:%")
+        req = urllib.request.Request(BASE_URL + encoded, method="HEAD")
+        with urllib.request.urlopen(req, timeout=TIMEOUT_SECONDS) as resp:
+            return path, resp.status
+    except urllib.error.HTTPError as e:
+        return path, e.code
+    except Exception as e:
+        return path, f"ERR:{type(e).__name__}:{e}"
+
+
+def main():
+    if not os.path.isdir(BUILD_DIR):
+        print(f"ERROR: build dir not found: {BUILD_DIR}", file=sys.stderr)
+        sys.exit(2)
+
+    pages = collect_pages(BUILD_DIR)
+    links = collect_internal_hrefs(pages)
+    print(f"Pages crawled: {len(pages)}  Unique internal paths: {len(links)}")
+
+    broken = []
+    with ThreadPoolExecutor(max_workers=PARALLELISM) as ex:
+        futs = {ex.submit(check_one, p): p for p in links}
+        for fut in as_completed(futs):
+            path, status = fut.result()
+            if (isinstance(status, int) and status >= 400) or isinstance(status, str):
+                broken.append((path, status))
+
+    if not broken:
+        print("OK: no broken internal links")
+        return 0
+
+    print(f"\nFOUND {len(broken)} broken internal link(s):")
+    for path, status in sorted(broken):
+        print(f"  [{status}]  {path}")
+        for src in sorted(links[path])[:5]:
+            print(f"      linked from: {src}")
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/components/header/index.js
+++ b/src/components/header/index.js
@@ -35,7 +35,7 @@ const Header = () => {
             }>
               <li><a href="/" className={styles.active}>Platform</a></li>
               <li><a href="/devportal/intro">Devportal</a></li>
-              <li><a href="/admin-cli/intro">Admin-UI</a></li>
+              <li><a href="/admin-ui/intro">Admin-UI</a></li>
             </ul>
         </section>
         <section className={styles.githubLink}>


### PR DESCRIPTION
## Why
Last PR (#23) flipped \`onBrokenLinks: throw\` and fixed every broken link Docusaurus could see — but a full HTML crawl of the build surfaced one more: \`/index_old\` (a legacy landing page) still rendering a stale header link to \`/admin-cli/intro\` (the product was renamed to \`admin-ui\`).

Docusaurus does not catch this class because the href lives in a raw \`<a href="...">\` inside a React component, not a markdown link or a doc route reference. The build never knows it should validate it.

## What this PR adds
1. **\`scripts/check-links.py\`** — walks every \`index.html\` under \`build/\`, extracts every internal absolute href, HEAD-pings each against a locally-served build. Exits non-zero on any 4xx/5xx.
2. **\`mcp-ci.yml\`** — after \`yarn build\`, starts \`yarn serve\` and runs the script. Future PRs that introduce a broken internal href fail CI.
3. **Header fix** — \`/admin-cli/intro\` -> \`/admin-ui/intro\` in \`src/components/header/index.js\`.

## Verification
Local: \`Pages crawled: 153  Unique internal paths: 158  OK: no broken internal links\`

## Why this matters
\`onBrokenLinks: throw\` (PR #23) and this HTML crawl are complementary:
- \`throw\`: catches Docusaurus-resolvable links at build time. Fast, no server needed.
- crawl: catches raw HTML hrefs that bypass the build's link resolver. Slower but exhaustive.

Together they make it structurally hard to ship a broken internal link.

🤖 Generated with [Claude Code](https://claude.com/claude-code)