### PR TITLE
Release: docs-mcp V1/V2 version selector to production

### DIFF
--- a/.github/workflows/publish-mcp.yml
+++ b/.github/workflows/publish-mcp.yml
@@ -39,10 +39,13 @@ jobs:
         run: yarn install --immutable
       - name: Build site (generates snapshot)
         run: yarn build
-      - name: Copy snapshot into mcp-server/bundled/
+      - name: Copy snapshots into mcp-server/bundled/
         run: |
           mkdir -p mcp-server/bundled
+          # V2 (current tree) and V1 (frozen) snapshots ship bundled so both
+          # `--version` selections work offline. Fail loudly if either is missing.
           cp build/mcp-snapshot.json mcp-server/bundled/snapshot.json
+          cp build/mcp-snapshot-v1.json mcp-server/bundled/snapshot-v1.json
       - name: Build MCP server
         run: yarn mcp:build
       - name: MCP CI (typecheck + lint + test)

--- a/README.md
+++ b/README.md
@@ -9,6 +9,22 @@ This website is built using [Docusaurus 3](https://docusaurus.io/), a modern sta
 | `develop` | `https://docs-next.platform.vee.codes/`     | Staging    |
 | `main`    | `https://docs.platform.vee.codes/`          | Production |
 
+## Docs MCP server
+
+The documentation is also available to CLI coding agents (Claude Code, Codex, Cursor) as an MCP server — [`@veecode-platform/docs-mcp`](mcp-server/README.md) — so an agent can search and read the docs without leaving the terminal.
+
+It serves **one DevPortal docs version per instance** (it never mixes V1 and V2):
+
+```bash
+# V1 (default — the split-image / profiles release most installs run today)
+claude mcp add veecode-docs --scope user -- npx -y @veecode-platform/docs-mcp
+
+# V2 (preview — the unified veecode/devportal:2.0.0 / presets release)
+claude mcp add veecode-docs-v2 --scope user -- npx -y @veecode-platform/docs-mcp --version v2
+```
+
+`platform`, `admin-ui`, and `vkdr` docs are version-neutral and present in both. Full setup (Codex CLI, manual `~/.mcp.json`, global install, env vars, the exposed tools, and how the snapshot stays fresh) is in the **[MCP server README](mcp-server/README.md)**.
+
 ## Development Workflow
 
 1. Create a feature branch off `develop`.

--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -2,25 +2,43 @@
 
 MCP server exposing the VeeCode Platform documentation (DevPortal, Platform, Admin-UI, VKDR-CLI) to CLI agents over stdio.
 
+## Pick a docs version: V1 or V2
+
+The server serves **one DevPortal docs version per instance** — it never mixes them. Choose with `--version v1|v2` (or `VEECODE_DOCS_MCP_VERSION`):
+
+- **`v1` (default)** — the split-image / profiles release (`VEECODE_PROFILE`). This is the production-default docs and what most installs run today.
+- **`v2`** — the unified `veecode/devportal:2.0.0` / presets release (currently a preview).
+
+The choice is bound for the whole session: search/get/list only return that version, and the background refresh only pulls that version's snapshot — so there is no cross-version drift. (`platform`, `admin-ui`, and `vkdr` docs are version-neutral and present in both.) Confirm the loaded version with the `get_snapshot_info` tool (`docs_version` field).
+
 ## Use with Claude Code
 
-One command, no global install:
+V1 (default) — no global install:
 
 ```bash
 claude mcp add veecode-docs --scope user \
   -- npx -y @veecode-platform/docs-mcp
 ```
 
-That's it. `npx` downloads the package on first call (~5s) and caches it for subsequent runs.
+V2 (preview) — pass `--version v2`:
 
-Or add to `~/.mcp.json` manually:
+```bash
+claude mcp add veecode-docs-v2 --scope user \
+  -- npx -y @veecode-platform/docs-mcp --version v2
+```
+
+`npx` downloads the package on first call (~5s) and caches it. You can add both side by side. Or add to `~/.mcp.json` manually:
 
 ```json
 {
   "mcpServers": {
     "veecode-docs": {
       "command": "npx",
-      "args": ["-y", "@veecode-platform/docs-mcp"]
+      "args": ["-y", "@veecode-platform/docs-mcp", "--version", "v1"]
+    },
+    "veecode-docs-v2": {
+      "command": "npx",
+      "args": ["-y", "@veecode-platform/docs-mcp", "--version", "v2"]
     }
   }
 }
@@ -33,7 +51,7 @@ Or add to `~/.mcp.json` manually:
 ```toml
 [mcp_servers.veecode-docs]
 command = "npx"
-args = ["-y", "@veecode-platform/docs-mcp"]
+args = ["-y", "@veecode-platform/docs-mcp", "--version", "v1"]
 ```
 
 ## Other install methods
@@ -42,8 +60,8 @@ If you'd rather not depend on `npx` resolution at launch:
 
 ```bash
 npm install -g @veecode-platform/docs-mcp
-# then point the MCP at the global binary
-claude mcp add veecode-docs --scope user -- veecode-docs-mcp
+# then point the MCP at the global binary (add --version v2 for the preview)
+claude mcp add veecode-docs --scope user -- veecode-docs-mcp --version v1
 ```
 
 ## Tools exposed
@@ -55,11 +73,11 @@ claude mcp add veecode-docs --scope user -- veecode-docs-mcp
 | `get_doc_outline` | Frontmatter + heading tree only — cheap preview |
 | `list_products` | Overview of the four VeeCode products |
 | `list_docs` | Directory tree within a product |
-| `get_snapshot_info` | Loaded snapshot version and freshness |
+| `get_snapshot_info` | Loaded snapshot version, **docs_version (v1/v2)**, and freshness |
 
 ## How it stays fresh
 
-The package ships with a snapshot bundled at publish time. On every launch, the server makes a non-blocking `HEAD` request to `https://docs.platform.vee.codes/mcp-snapshot.json`; if newer, it downloads the snapshot into `~/.cache/veecode-docs-mcp/` for use on the next launch.
+The package ships with both version snapshots bundled at publish time. On every launch, the server makes a non-blocking `HEAD` request to the snapshot URL for the **selected version** (`mcp-snapshot.json` for v2, `mcp-snapshot-v1.json` for v1); if newer, it downloads it into `~/.cache/veecode-docs-mcp/` for use on the next launch. The refresh is version-scoped, so it never pulls the other version's content.
 
 The running session never swaps mid-conversation, so the agent's view of the docs is stable for the lifetime of the session.
 
@@ -67,8 +85,9 @@ The running session never swaps mid-conversation, so the agent's view of the doc
 
 | Variable | Effect |
 |----------|--------|
+| `VEECODE_DOCS_MCP_VERSION=v1\|v2` | Docs version to serve (default `v1`). Same as the `--version` flag. |
 | `VEECODE_DOCS_MCP_OFFLINE=1` | Skip the remote refresh check |
-| `VEECODE_DOCS_MCP_SNAPSHOT_URL=<url>` | Override the snapshot URL |
+| `VEECODE_DOCS_MCP_SNAPSHOT_URL=<url>` | Override the snapshot URL (takes precedence over the version default) |
 | `VEECODE_DOCS_MCP_CACHE_DIR=<path>` | Override the cache directory |
 
 ## Language

--- a/mcp-server/src/server.ts
+++ b/mcp-server/src/server.ts
@@ -81,13 +81,38 @@ const TOOLS = [
   },
 ] as const;
 
-function defaultBundledPath(): string {
-  const here = dirname(fileURLToPath(import.meta.url));
-  return join(here, "..", "bundled", "snapshot.json");
+export type DocsVersion = "v1" | "v2";
+
+// Each docs version maps to its own bundled snapshot file and refresh URL. The
+// snapshots are built separately (see plugins/mcp-snapshot): mcp-snapshot.json is
+// the current/V2 tree, mcp-snapshot-v1.json is the frozen V1 tree. Binding the
+// refresh URL per-version means the auto-refresh can never pull the other
+// version's content — no cross-version drift.
+const SNAPSHOT_SOURCES: Record<DocsVersion, { bundledFile: string; remoteUrl: string }> = {
+  v1: {
+    bundledFile: "snapshot-v1.json",
+    remoteUrl: "https://docs.platform.vee.codes/mcp-snapshot-v1.json",
+  },
+  v2: {
+    bundledFile: "snapshot.json",
+    remoteUrl: "https://docs.platform.vee.codes/mcp-snapshot.json",
+  },
+};
+
+// Default is v1: it is the production-default docs version and what most installs
+// run today. Pass --version v2 (or VEECODE_DOCS_MCP_VERSION=v2) for the preview.
+function resolveVersion(opt?: string): DocsVersion {
+  const raw = (opt ?? process.env.VEECODE_DOCS_MCP_VERSION ?? "v1").toLowerCase();
+  return raw === "v2" ? "v2" : "v1";
 }
 
-function resolveBundledPath(opt?: string): string {
-  return opt ?? process.env.VEECODE_DOCS_MCP_BUNDLED_PATH ?? defaultBundledPath();
+function defaultBundledPath(version: DocsVersion): string {
+  const here = dirname(fileURLToPath(import.meta.url));
+  return join(here, "..", "bundled", SNAPSHOT_SOURCES[version].bundledFile);
+}
+
+function resolveBundledPath(version: DocsVersion, opt?: string): string {
+  return opt ?? process.env.VEECODE_DOCS_MCP_BUNDLED_PATH ?? defaultBundledPath(version);
 }
 
 function defaultCacheDir(): string {
@@ -98,6 +123,8 @@ function defaultCacheDir(): string {
 }
 
 export interface CreateServerOptions {
+  /** Docs version to serve: "v1" (default) or "v2" (preview). */
+  version?: DocsVersion | string;
   bundledPath?: string;
   cacheDir?: string | null;
   remoteUrl?: string | null;
@@ -108,7 +135,8 @@ export async function createServer(opts: CreateServerOptions = {}): Promise<{
   server: Server;
   dispose: () => Promise<void>;
 }> {
-  const bundledPath = resolveBundledPath(opts.bundledPath);
+  const version = resolveVersion(opts.version);
+  const bundledPath = resolveBundledPath(version, opts.bundledPath);
   const cacheDir =
     opts.cacheDir === null
       ? null
@@ -116,7 +144,7 @@ export async function createServer(opts: CreateServerOptions = {}): Promise<{
   const remoteUrl =
     opts.remoteUrl ??
     process.env.VEECODE_DOCS_MCP_SNAPSHOT_URL ??
-    "https://docs.platform.vee.codes/mcp-snapshot.json";
+    SNAPSHOT_SOURCES[version].remoteUrl;
   const offline =
     opts.offline ?? process.env.VEECODE_DOCS_MCP_OFFLINE === "1";
 
@@ -160,6 +188,7 @@ export async function createServer(opts: CreateServerOptions = {}): Promise<{
           source: loaded.source,
           bundledVersion: loaded.bundledVersion,
           refreshStatus,
+          docsVersion: version,
         });
         break;
       default:
@@ -174,8 +203,18 @@ export async function createServer(opts: CreateServerOptions = {}): Promise<{
   };
 }
 
+/** Parse `--version <v1|v2>` / `--version=<v1|v2>` from argv (CLI flag wins over env). */
+function parseVersionArg(argv: string[]): string | undefined {
+  const eq = argv.find((a) => a.startsWith("--version="));
+  if (eq) return eq.slice("--version=".length);
+  const i = argv.indexOf("--version");
+  if (i !== -1 && argv[i + 1]) return argv[i + 1];
+  return undefined;
+}
+
 export async function startServer(): Promise<void> {
-  const { server } = await createServer();
+  const version = parseVersionArg(process.argv.slice(2));
+  const { server } = await createServer(version ? { version } : {});
   const transport = new StdioServerTransport();
   await server.connect(transport);
 }

--- a/mcp-server/src/tools/get-snapshot-info.ts
+++ b/mcp-server/src/tools/get-snapshot-info.ts
@@ -6,9 +6,12 @@ export interface SnapshotInfoInput {
   source: LoadSource;
   bundledVersion: string;
   refreshStatus: RefreshStatus;
+  docsVersion?: "v1" | "v2";
 }
 
 export interface SnapshotInfo {
+  /** Which DevPortal docs line this server is serving: "v1" (default) or "v2" (preview). */
+  docs_version: "v1" | "v2";
   version: string;
   generated_at: string;
   source: LoadSource;
@@ -21,6 +24,7 @@ export interface SnapshotInfo {
 export function getSnapshotInfo(input: SnapshotInfoInput): SnapshotInfo {
   const section_count = input.snapshot.docs.reduce((n, d) => n + d.sections.length, 0);
   return {
+    docs_version: input.docsVersion ?? "v1",
     version: input.snapshot.version,
     generated_at: input.snapshot.generatedAt,
     source: input.source,

--- a/mcp-server/tests/integration/mcp-protocol.test.ts
+++ b/mcp-server/tests/integration/mcp-protocol.test.ts
@@ -10,7 +10,7 @@ const bundledPath = join(here, "..", "fixtures", "snapshot.json");
 
 describe("MCP protocol", () => {
   it("lists all six tools", async () => {
-    const { server, dispose } = await createServer({ bundledPath, offline: true });
+    const { server, dispose } = await createServer({ bundledPath, offline: true, cacheDir: null });
 
     const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
     const client = new Client({ name: "test", version: "0.0.0" }, { capabilities: {} });
@@ -31,7 +31,7 @@ describe("MCP protocol", () => {
   });
 
   it("calls search_docs through the protocol", async () => {
-    const { server, dispose } = await createServer({ bundledPath, offline: true });
+    const { server, dispose } = await createServer({ bundledPath, offline: true, cacheDir: null });
     const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
     const client = new Client({ name: "test", version: "0.0.0" }, { capabilities: {} });
     await Promise.all([server.connect(serverTransport), client.connect(clientTransport)]);

--- a/mcp-server/tests/unit/server-options.test.ts
+++ b/mcp-server/tests/unit/server-options.test.ts
@@ -27,4 +27,23 @@ describe("createServer bundledPath resolution", () => {
     expect(server).toBeTruthy();
     await dispose();
   });
+
+  it("accepts an explicit version with an explicit bundledPath", async () => {
+    for (const version of ["v1", "v2"] as const) {
+      const { server, dispose } = await createServer({
+        version,
+        bundledPath: fixturePath,
+        offline: true,
+      });
+      expect(server).toBeTruthy();
+      await dispose();
+    }
+  });
+
+  it("honors VEECODE_DOCS_MCP_VERSION env var (unknown value falls back, no throw)", async () => {
+    process.env.VEECODE_DOCS_MCP_VERSION = "bogus";
+    const { server, dispose } = await createServer({ bundledPath: fixturePath, offline: true });
+    expect(server).toBeTruthy();
+    await dispose();
+  });
 });

--- a/mcp-server/tests/unit/tools/get-snapshot-info.test.ts
+++ b/mcp-server/tests/unit/tools/get-snapshot-info.test.ts
@@ -11,14 +11,16 @@ const snapshot: Snapshot = JSON.parse(
 );
 
 describe("get_snapshot_info", () => {
-  it("returns version, source, bundled_version, counts, refresh_status", () => {
+  it("returns docs_version, version, source, bundled_version, counts, refresh_status", () => {
     const result = getSnapshotInfo({
       snapshot,
       source: "bundled",
       bundledVersion: snapshot.version,
       refreshStatus: "up-to-date",
+      docsVersion: "v2",
     });
     expect(result).toEqual({
+      docs_version: "v2",
       version: snapshot.version,
       generated_at: snapshot.generatedAt,
       source: "bundled",
@@ -27,5 +29,15 @@ describe("get_snapshot_info", () => {
       section_count: 3,
       refresh_status: "up-to-date",
     });
+  });
+
+  it("defaults docs_version to v1 when not provided", () => {
+    const result = getSnapshotInfo({
+      snapshot,
+      source: "bundled",
+      bundledVersion: snapshot.version,
+      refreshStatus: "up-to-date",
+    });
+    expect(result.docs_version).toBe("v1");
   });
 });


### PR DESCRIPTION
Promotes the docs-mcp version selector (PR #30) to production.

On merge, `publish-mcp.yml` auto-bumps `@veecode-platform/docs-mcp` (minor — `mcp-server/src/` changed) and publishes it with:
- `--version v1|v2` selector (default v1), per-version bundled snapshot + refresh URL (no cross-version drift)
- both snapshots bundled for offline use
- `docs_version` in `get_snapshot_info`
- updated install docs (mcp-server/README + repo README)

Diff is mcp-server/ + publish workflow + README only. CI green on #30.

🤖 Generated with [Claude Code](https://claude.com/claude-code)