### PR TITLE
docs(v2): dynamic-plugins.default.yaml is vitrine only (reflects platform PR #46)

### DIFF
--- a/devportal/concepts/dynamic-plugins.md
+++ b/devportal/concepts/dynamic-plugins.md
@@ -47,17 +47,19 @@ provider. They are extracted into the image at build time and need no preset.
 
 ---
 
-## The catalog: `dynamic-plugins.default.yaml`
+## The reference catalog: `dynamic-plugins.default.yaml`
 
-`dynamic-plugins.default.yaml` is the **catalog** (the *vitrine*) — the
-authoritative list of every optional plugin the image knows about. Every
-optional entry ships with `disabled: true`. **No optional plugin is on by
-default**; the image boots to a working shell with only the pre-installed chrome
-plugins visible.
+`dynamic-plugins.default.yaml` is the **reference catalog** (the *vitrine*) — a
+browsable list of every optional plugin the image bundles, with package names and
+default OCI references. It is **not part of the boot chain**.
 
-Editing this file changes what *is available*, not what *is enabled*. Do not
-edit it to enable a plugin for one deployment — it is image-level configuration.
-Use one of the selection surfaces below instead.
+Every optional entry is listed with `disabled: true` as its default state. Use
+the catalog to look up a plugin's package name or OCI reference before enabling
+it via a preset or `dynamic-plugins.yaml`. A plugin not listed here works fine
+if declared directly in `dynamic-plugins.yaml`.
+
+Do not edit it to enable a plugin for one deployment — it is image-level
+documentation. Use one of the selection surfaces below instead.
 
 ---
 
@@ -67,13 +69,10 @@ A plugin is enabled if **any** selection surface includes it. There are three:
 
 ### 1. Presets (`VEECODE_PRESETS`) — recommended
 
-Presets flip `disabled: false` for the plugins they enable. Critically, the
-plugin's `pluginConfig:` block (mount points, dynamic routes, RBAC scopes, menu
-items) stays in `dynamic-plugins.default.yaml`. A preset entry only carries the
-`package:` key and `disabled: false` — `install-dynamic-plugins.py` merges
-records shallow by `package:` key, so the default's `pluginConfig:` attaches
-automatically. Enabling an existing plugin via a new preset is a ~3-line YAML
-addition. See [Presets](./presets.md).
+Presets enable the plugins they declare. Each preset entry is self-contained — it
+carries `package:`, `disabled: false`, and the full `pluginConfig:` (mount
+points, dynamic routes, RBAC scopes, menu items) inline. No merge with
+`dynamic-plugins.default.yaml` is needed at runtime. See [Presets](./presets.md).
 
 ### 2. Operator override — mounted `dynamic-plugins.yaml`
 
@@ -93,8 +92,8 @@ which is included in the plugin chain on the next restart and **survives
 container restarts** as long as the `/app/data` volume is retained. (This is why
 `/app/data` must be a directory volume, not a single-file bind mount.)
 
-:::note The catalog and the marketplace index are independent
-The boot catalog (`dynamic-plugins.default.yaml`) and the marketplace's
+:::note The reference catalog and the marketplace index are independent
+`dynamic-plugins.default.yaml` (reference catalog) and the marketplace's
 `plugin-catalog-index` are two independent artifacts that share content but are
 maintained separately. Editing one does not sync the other. The unification of
 the two is a deferred decision — see
@@ -109,7 +108,7 @@ For the full precedence table when surfaces conflict, see
 
 ## OCI reference shape
 
-OCI plugin references in `dynamic-plugins.default.yaml` follow this pattern:
+OCI plugin references used in presets and `dynamic-plugins.yaml` follow this pattern:
 
 ```
 oci://${PLUGIN_REGISTRY}/<workspace>:bs_${BACKSTAGE_VERSION}!<selector>
@@ -163,10 +162,9 @@ At container start, before Backstage accepts requests:
 
 1. **Preset resolver** validates required env vars (exit 78 on missing) and
    writes a `preset-<name>-plugins.yaml` for each preset with a `plugins:` list.
-2. **Assemble the includes chain** — `dynamic-plugins.yaml` and
-   `dynamic-plugins.default.yaml` are copied to writable working files and the
-   `includes:` chain is rebuilt to reference the catalog, the marketplace file,
-   and each preset's plugin file.
+2. **Assemble the includes chain** — `dynamic-plugins.yaml` is copied to a
+   writable working file and the `includes:` chain is rebuilt to reference the
+   marketplace file and each preset's plugin file.
 3. **`${BACKSTAGE_VERSION}` and `${PLUGIN_REGISTRY}` substitution** across the
    working files.
 4. **`install-dynamic-plugins.py`** — for each enabled entry, `skopeo copy`

--- a/devportal/concepts/presets.md
+++ b/devportal/concepts/presets.md
@@ -35,7 +35,7 @@ things:
 | Field | Purpose |
 | --- | --- |
 | `requires.variables` | The environment variables the operator must supply, each with a description, `required` flag, optional `docs` URL, and `example`. |
-| `plugins` | The dynamic plugins the situation needs, as OCI references (`oci://...!<selector>`). Each entry's `package:` must match an entry in `dynamic-plugins.default.yaml` so the resolver flips it from `disabled: true` to `disabled: false`. |
+| `plugins` | The dynamic plugins the situation needs. Each entry is self-contained: `package:` (OCI reference), `disabled: false`, and the full `pluginConfig:` block inline. |
 | `appConfig` | The Backstage `app-config` block those plugins expect. Written to its own `app-config.preset-<name>.yaml` and passed to Backstage as a `--config` file. |
 
 Many integration presets carry an empty `plugins: []` list — their backend
@@ -73,12 +73,12 @@ An operator-mounted `app-config.local.yaml` always wins over preset-generated
 configs. See [Configuration Hierarchy](./configuration-hierarchy.md) for the
 full precedence chain.
 
-:::warning The `package:` value must match exactly
-A preset's `package:` string must match the entry in
-`dynamic-plugins.default.yaml` verbatim — including the `${PLUGIN_REGISTRY}`
-and `${BACKSTAGE_VERSION}` variable forms. A mismatch installs the plugin a
-second time under a different name and the backend crashes on duplicate
-registration.
+:::warning The `package:` value must be unique across all sources
+If the same plugin is declared in both a preset and `dynamic-plugins.yaml`, the
+`package:` strings must be identical — including the `${PLUGIN_REGISTRY}` and
+`${BACKSTAGE_VERSION}` variable forms. A mismatch causes the install script to
+treat them as two distinct plugins, installing the bundle twice and crashing the
+backend on duplicate registration.
 :::
 
 ---

--- a/devportal/installation-guide/FAQs.md
+++ b/devportal/installation-guide/FAQs.md
@@ -111,7 +111,7 @@ See [Dynamic Plugins](./docker-local/custom-plugins.md) for mount instructions.
 
 ### Why do I only set `plugins:` in `dynamic-plugins.yaml`, not `includes:`?
 
-In V2 the entrypoint owns the `includes:` chain. On every boot it copies your mounted `dynamic-plugins.yaml` to a writable shadow and rebuilds `includes:` to prepend the resolved image defaults (`dynamic-plugins.default.resolved.yaml`), the marketplace state, and each selected preset's plugin fragment. Any `includes:` you write yourself is **replaced**.
+In V2 the entrypoint owns the `includes:` chain. On every boot it copies your mounted `dynamic-plugins.yaml` to a writable shadow and rebuilds `includes:` to prepend the marketplace state and each selected preset's plugin fragment. Any `includes:` you write yourself is **replaced**.
 
 So you provide only a top-level `plugins:` list:
 
@@ -121,7 +121,7 @@ plugins:
     disabled: false
 ```
 
-You cannot accidentally lose the pre-installed plugins by omitting the defaults, and you never reference `dynamic-plugins.default.resolved.yaml` yourself. (This differs from the V1 distro, where the defaults had to be included manually.) If your mounted `dynamic-plugins.yaml` is malformed YAML, the boot aborts with exit code **78** rather than silently dropping plugins.
+You cannot accidentally lose the pre-installed plugins — the core plugins are declared directly in `dynamic-plugins.yaml` with `preInstalled: true` and are always merged in. (This differs from V1, where the defaults had to be included manually.) If your mounted `dynamic-plugins.yaml` is malformed YAML, the boot aborts with exit code **78** rather than silently dropping plugins.
 
 ---
 

--- a/devportal/installation-guide/docker-local/custom-plugins.md
+++ b/devportal/installation-guide/docker-local/custom-plugins.md
@@ -84,7 +84,7 @@ plugins:
 
 ## How merging works — the entrypoint owns `includes:`
 
-You provide only a top-level `plugins:` list. You do **not** write an `includes:` key. On every boot the entrypoint copies your `dynamic-plugins.yaml` to a writable shadow and **rebuilds** the `includes:` chain itself, prepending the resolved image defaults, the marketplace state, and any preset fragments. Any `includes:` you add is replaced — so you cannot accidentally drop the pre-installed plugins by omitting it:
+You provide only a top-level `plugins:` list. You do **not** write an `includes:` key. On every boot the entrypoint copies your `dynamic-plugins.yaml` to a writable shadow and **rebuilds** the `includes:` chain itself, prepending the marketplace state and any preset fragments. Any `includes:` you add is replaced — so you cannot accidentally drop the pre-installed plugins:
 
 ```yaml
 plugins:
@@ -92,8 +92,6 @@ plugins:
   - package: './dynamic-plugins/dist/some-plugin-dynamic'
     disabled: false
 ```
-
-(The entrypoint-owned shadow it prepends is `dynamic-plugins.default.resolved.yaml`, the image defaults with `${BACKSTAGE_VERSION}` and `${PLUGIN_REGISTRY}` already substituted. It exists for the entrypoint's use — you don't reference it.)
 
 After the plugin install script runs, it generates `dynamic-plugins-root/app-config.dynamic-plugins.yaml` from the `pluginConfig` blocks of all enabled plugins. This generated file loads after your `app-config.local.yaml` (and before `app-config.saas.yaml` in SaaS deployments).
 

--- a/devportal/plugins/bundled/about.md
+++ b/devportal/plugins/bundled/about.md
@@ -30,7 +30,7 @@ The About plugin displays version and instance information for the DevPortal dep
 
 ---
 
-## Mount point configuration (from `dynamic-plugins.default.yaml`)
+## Mount point configuration
 
 ```yaml
 pluginConfig:

--- a/devportal/plugins/bundled/github-actions.md
+++ b/devportal/plugins/bundled/github-actions.md
@@ -10,7 +10,7 @@ Without this plugin, CI history lives only in GitHub — the developer has to le
 
 The GitHub Actions plugin displays GitHub Actions workflow run history in the CI tab of catalog entities. It is the standard Backstage community plugin for GitHub Actions integration.
 
-**Status:** Ships in the bundled catalog (`dynamic-plugins.default.yaml`) with `disabled: true`. Fetched from the OCI registry at boot when enabled — no image rebuild needed. Activated automatically by the `github` preset.
+**Status:** Listed in `dynamic-plugins.default.yaml` (reference) as `disabled: true`. Fetched from the OCI registry at boot when enabled — no image rebuild needed. Activated automatically by the `github` preset.
 
 ---
 

--- a/devportal/plugins/bundled/homepage.md
+++ b/devportal/plugins/bundled/homepage.md
@@ -26,7 +26,7 @@ The VeeCode Homepage plugin provides the customizable landing page for DevPortal
 
 ---
 
-## Mount point configuration (from `dynamic-plugins.default.yaml`)
+## Mount point configuration
 
 ```yaml
 pluginConfig:

--- a/devportal/plugins/bundled/index.md
+++ b/devportal/plugins/bundled/index.md
@@ -8,7 +8,7 @@ title: Bundled Plugin Catalog
 
 DevPortal ships with a set of **preinstalled dynamic plugins** baked into the distro image. They are available immediately — no download or rebuild needed. Most are **disabled by default** and are enabled by adding an entry to `dynamic-plugins.yaml` (or via the Marketplace).
 
-A few core plugins (`preInstalled: true` in `dynamic-plugins.default.yaml`) are always loaded — they power the UI shell, navigation, and marketplace itself.
+A few core plugins (`preInstalled: true` in `dynamic-plugins.yaml`) are always loaded — they power the UI shell, navigation, and marketplace itself.
 
 Think of this catalog in terms of capability layers, not a flat install list. The always-on plugins establish the shell. The disabled-by-default plugins represent operational capabilities — CI/CD visibility, infrastructure observability, code quality — that your team activates based on what context-switches it wants to eliminate. Each plugin connects to a service entity via an annotation; the right question before enabling any plugin is "which entities will carry this annotation, and what does it replace for their developers?" See [Composing a Portal](/devportal/v2/concepts/portal-composition) for the full three-layer model.
 

--- a/devportal/plugins/bundled/jenkins.md
+++ b/devportal/plugins/bundled/jenkins.md
@@ -10,7 +10,7 @@ Without this plugin, build status lives in Jenkins — developers context-switch
 
 The Jenkins plugin displays Jenkins build status in catalog entity pages.
 
-**Status:** Ships in the bundled catalog (`dynamic-plugins.default.yaml`) with `disabled: true`. Fetched from the OCI registry at boot when enabled — no image rebuild needed. Activated automatically by the `jenkins` preset.
+**Status:** Listed in `dynamic-plugins.default.yaml` (reference) as `disabled: true`. Fetched from the OCI registry at boot when enabled — no image rebuild needed. Activated automatically by the `jenkins` preset.
 
 ---
 

--- a/devportal/plugins/bundled/marketplace.md
+++ b/devportal/plugins/bundled/marketplace.md
@@ -46,7 +46,7 @@ This means Marketplace selections **persist across restarts** once the pod is re
 
 ---
 
-## Mount point configuration (from `dynamic-plugins.default.yaml`)
+## Mount point configuration
 
 ```yaml
 pluginConfig:

--- a/devportal/plugins/bundled/pending-changes.md
+++ b/devportal/plugins/bundled/pending-changes.md
@@ -26,7 +26,7 @@ The Pending Changes plugin adds a badge to the Global Header indicating that plu
 
 ---
 
-## Mount point configuration (from `dynamic-plugins.default.yaml`)
+## Mount point configuration
 
 ```yaml
 pluginConfig:

--- a/devportal/plugins/bundled/tech-radar.md
+++ b/devportal/plugins/bundled/tech-radar.md
@@ -29,7 +29,7 @@ The Tech Radar plugin provides a visual technology adoption radar, helping teams
 
 ---
 
-## Mount point configuration (from `dynamic-plugins.default.yaml`)
+## Mount point configuration
 
 ```yaml
 pluginConfig:

--- a/devportal/plugins/development/loading.md
+++ b/devportal/plugins/development/loading.md
@@ -21,7 +21,7 @@ plugins:
     disabled: false
 ```
 
-You only provide `plugins:`. The entrypoint owns the `includes:` chain — on every boot it copies your file to a writable shadow and rebuilds `includes:` to prepend the resolved image defaults (`dynamic-plugins.default.resolved.yaml`), the marketplace state, and each preset fragment. An `includes:` block you add yourself is replaced, so you never need to (and shouldn't) reference the defaults manually.
+You only provide `plugins:`. The entrypoint owns the `includes:` chain — on every boot it copies your file to a writable shadow and rebuilds `includes:` to prepend the marketplace state and each preset fragment. An `includes:` block you add yourself is replaced, so you never need to write one.
 
 Mount it in your compose file or Kubernetes Deployment manifest — see [Adding Plugins](../adding.md) for the exact volume/ConfigMap syntax.
 

--- a/devportal/plugins/finding.md
+++ b/devportal/plugins/finding.md
@@ -36,4 +36,6 @@ The Backstage plugin ecosystem does not yet have a universal standard for publis
 
 ## Checking what is already bundled
 
-Review `dynamic-plugins.default.yaml` in the DevPortal distro for the definitive list of bundled plugins and their package names. All entries with `preInstalled: true` are always active; entries with `disabled: true` are available but need enabling.
+`dynamic-plugins.default.yaml` in the DevPortal distro is a convenience reference listing bundled plugin packages and their default configuration — useful for finding a plugin's package name. It is not part of the boot chain.
+
+The always-on plugins are declared in `dynamic-plugins.yaml` with `preInstalled: true` and carry their full `pluginConfig` there. Optional plugins are enabled by declaring them in your `dynamic-plugins.yaml` or by activating a preset — no `includes` reference to `.default.yaml` is required. A plugin not listed in `.default.yaml` works fine if declared directly in `dynamic-plugins.yaml`.

--- a/devportal/plugins/kubernetes.md
+++ b/devportal/plugins/kubernetes.md
@@ -12,7 +12,7 @@ With the plugin enabled, the entity page becomes the operational view for the se
 
 The Kubernetes plugin displays the live state of Kubernetes resources — pods, deployments, services, and more — for a catalog entity. It appears as a **Kubernetes tab on the entity page** (not a sidebar item).
 
-The plugin ships in the **bundled catalog** (`dynamic-plugins.default.yaml`) with `disabled: true`. It is fetched from the OCI registry at boot when enabled — no image rebuild or support contact is needed. The recommended activation path is the `kubernetes` preset.
+The plugin is listed in `dynamic-plugins.default.yaml` (reference) as `disabled: true`. It is fetched from the OCI registry at boot when enabled — no image rebuild or support contact is needed. The recommended activation path is the `kubernetes` preset.
 
 ---
 


### PR DESCRIPTION
## Summary

- `dynamic-plugins.default.yaml` is now documentation-only (vitrine). The operational boot chain is `dynamic-plugins.yaml` (always-on plugins with `preInstalled: true` + full `pluginConfig`) and preset files (self-contained with `pluginConfig` inline). Reflects [devportal-platform PR #46](https://github.com/veecode-platform/devportal-platform/pull/46).
- Removed all V2 text that described `.default.yaml` as a boot prerequisite, a merge source for preset `pluginConfig`, or part of the `includes:` chain.
- Removed references to the now-deleted `dynamic-plugins.default.resolved.yaml` shadow file from three installation guide pages.

## Files changed

| File | Change |
|---|---|
| `concepts/dynamic-plugins.md` | Section renamed "reference catalog"; preset paragraph rewritten; boot sequence step 2, note, and OCI reference intro updated |
| `concepts/presets.md` | `plugins` field description and duplicate-registration warning updated |
| `plugins/finding.md` | "Checking what is already bundled" rewritten; `preInstalled` reference corrected to `dynamic-plugins.yaml` |
| `plugins/bundled/index.md` | `preInstalled: true` source corrected to `dynamic-plugins.yaml` |
| `plugins/bundled/{about,homepage,marketplace,pending-changes,tech-radar}.md` | Removed `(from dynamic-plugins.default.yaml)` from `pluginConfig` section headings |
| `plugins/bundled/{github-actions,jenkins}.md`, `plugins/kubernetes.md` | Status lines updated to "listed in ... (reference)" |
| `installation-guide/FAQs.md` | Removed `dynamic-plugins.default.resolved.yaml` from includes chain description |
| `installation-guide/docker-local/custom-plugins.md` | Same; removed parenthetical explaining the deleted shadow file |
| `plugins/development/loading.md` | Same |

## Test plan

- [ ] Staging deploy — verify pages render at `/devportal/v2/concepts/dynamic-plugins`, `/devportal/v2/concepts/presets`, and the bundled plugin pages
- [ ] No broken links (Docusaurus build passes)
- [ ] V1 pages (`versioned_docs/version-v1/`) unchanged — confirm `.default.yaml` references remain in V1

🤖 Generated with [Claude Code](https://claude.com/claude-code)