### PR TITLE
docs(devportal): clarify V2 chart install path in migration guide

### DIFF
--- a/devportal/installation-guide/production-setup/setup.md
+++ b/devportal/installation-guide/production-setup/setup.md
@@ -19,7 +19,8 @@ For environments where Helm is not available, a [no-Helm fallback](#no-helm-fall
 helm repo add next-charts https://veecode-platform.github.io/next-charts
 helm repo update next-charts
 helm search repo veecode-devportal-platform
-# should show: 0.1.0 / 2.1.3
+# should show a CHART VERSION / APP VERSION pair, e.g. 0.4.0 / 2.2.0 — check
+# https://veecode-platform.github.io/next-charts/index.yaml for the current latest
 ```
 
 ---

--- a/devportal/migrating-from-v1.md
+++ b/devportal/migrating-from-v1.md
@@ -174,7 +174,19 @@ Two deltas have no V1 equivalent and are easy to miss:
 
 Pick the path that matches V1's:
 
-- **Production Kubernetes** → the published `veecode-devportal-platform` Helm chart. See [Kubernetes (Helm chart)](./installation-guide/production-setup/plan.md).
+- **Production Kubernetes** → the published `veecode-devportal-platform` Helm chart from the `next-charts` repo. This is **not** the same as installing from a local chart checkout (`helm install dp ./veecode-devportal-platform-chart`) — that path is for chart maintainers only:
+
+  ```bash
+  helm repo add next-charts https://veecode-platform.github.io/next-charts
+  helm repo update next-charts
+
+  helm install devportal next-charts/veecode-devportal-platform \
+    --namespace platform --create-namespace \
+    --set 'presets={recommended,veecode-theme,<your-integration-presets>}' \
+    --set existingSecret=my-devportal-creds
+  ```
+
+  Full walkthrough (Secret creation, PostgreSQL, ingress, upgrading): [Deploy to Kubernetes](./installation-guide/production-setup/setup.md).
 - **Local Kubernetes (VKDR)** → `vkdr devportal-platform install`. See [VKDR (Local Kubernetes)](./installation-guide/vkdr-local/vkdr-setup.md).
 - **Docker** → `veecode/devportal:2.1.3` with `VEECODE_PRESETS`. See [Docker Run](./installation-guide/docker-local/intro.md).
 


### PR DESCRIPTION
## Summary
- The migration guide's "Installing V2" section only linked out to the setup guide instead of showing the actual install command, and the chart's own README quick-start used a local checkout path that reads as the normal-usage command.
- Inlines the `helm repo add` + `helm install next-charts/veecode-devportal-platform` form directly in the migration guide, and calls out that the local-path form (`./veecode-devportal-platform-chart`) is for chart maintainers only.
- Also de-hardcodes the stale example chart/app version shown in the install guide's `helm search repo` step (was `0.1.0 / 2.1.3`, actual latest is `0.4.0 / 2.2.0`) — points to the live index instead so it doesn't go stale again.

## Test plan
- [x] Verified against the live `https://veecode-platform.github.io/next-charts/index.yaml` that `veecode-devportal-platform` is published (latest 0.4.0 / appVersion 2.2.0)
- [ ] Docs preview build (staging) renders the new inline command block correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)