### PR TITLE
docs(devportal): add helm upgrade command to migration guide

### DIFF
--- a/devportal/migrating-from-v1.md
+++ b/devportal/migrating-from-v1.md
@@ -186,7 +186,16 @@ Pick the path that matches V1's:
     --set existingSecret=my-devportal-creds
   ```
 
-  Full walkthrough (Secret creation, PostgreSQL, ingress, upgrading): [Deploy to Kubernetes](./installation-guide/production-setup/setup.md).
+  Once V2 is installed, later chart-version bumps are a normal `helm upgrade` — this one *is* an in-place update, unlike the V1→V2 move itself:
+
+  ```bash
+  helm upgrade devportal next-charts/veecode-devportal-platform \
+    --namespace platform \
+    --reuse-values \
+    --set existingSecret=my-devportal-creds
+  ```
+
+  Full walkthrough (Secret creation, PostgreSQL, ingress): [Deploy to Kubernetes](./installation-guide/production-setup/setup.md).
 - **Local Kubernetes (VKDR)** → `vkdr devportal-platform install`. See [VKDR (Local Kubernetes)](./installation-guide/vkdr-local/vkdr-setup.md).
 - **Docker** → `veecode/devportal:2.1.3` with `VEECODE_PRESETS`. See [Docker Run](./installation-guide/docker-local/intro.md).
 


### PR DESCRIPTION
## Summary
- Follow-up to #38: the migration guide showed the fresh-install command but only linked out for the `helm upgrade` command needed once V2 is running.
- Inlines the upgrade command directly in the "Installing V2" section, with a note clarifying it's unrelated to the one-time V1→V2 chart swap (which is a fresh install, not an upgrade).

🤖 Generated with [Claude Code](https://claude.com/claude-code)