### PR TITLE
Promote develop to main

### DIFF
--- a/devportal/installation-guide/production-setup/setup.md
+++ b/devportal/installation-guide/production-setup/setup.md
@@ -13,7 +13,9 @@ For environments where Helm is not available, a [no-Helm fallback](#no-helm-fall
 
 ---
 
-## Step 1: Add the Helm repository
+## Step 1: Add the Helm repository (optional)
+
+The install and upgrade commands in this guide point straight at the chart repo URL with `--repo`, so this step isn't required. Add it only if you want a persistent local alias — useful for `helm search`/`helm show values` outside of an install:
 
 ```bash
 helm repo add next-charts https://veecode-platform.github.io/next-charts
@@ -22,6 +24,8 @@ helm search repo veecode-devportal-platform
 # should show a CHART VERSION / APP VERSION pair, e.g. 0.4.0 / 2.2.0 — check
 # https://veecode-platform.github.io/next-charts/index.yaml for the current latest
 ```
+
+With the alias in place, swap `veecode-devportal-platform --repo https://veecode-platform.github.io/next-charts` for `next-charts/veecode-devportal-platform` in any command below.
 
 ---
 
@@ -115,7 +119,8 @@ For AWS RDS, prefer a Multi-AZ instance — with PVCs removed the database becom
 With `database.external.enabled=true` the chart disables the internal SQLite path and injects a `backend.database` block using the `PG_*` credentials from your Secret. Remove both PVCs — the pod becomes fully stateless and schedules in any availability zone:
 
 ```bash
-helm install devportal next-charts/veecode-devportal-platform \
+helm install devportal veecode-devportal-platform \
+  --repo https://veecode-platform.github.io/next-charts \
   --namespace platform \
   --create-namespace \
   --set 'presets={recommended,github,github-auth}' \
@@ -132,7 +137,8 @@ With stateless pods, `replicaCount > 1` is safe for steady-state traffic. Add `-
 The default path provisions two PVCs (`/app/data` and `/app/dynamic-plugins-root`). Suitable for a single-node dev cluster; an EBS- or RWO-backed PVC pins the pod to one availability zone and is not recommended for production:
 
 ```bash
-helm install devportal next-charts/veecode-devportal-platform \
+helm install devportal veecode-devportal-platform \
+  --repo https://veecode-platform.github.io/next-charts \
   --namespace platform \
   --create-namespace \
   --set 'presets={recommended,github,github-auth}' \
@@ -196,7 +202,8 @@ If a required variable is missing, the container exits with **code 78** and logs
 ## Upgrading
 
 ```bash
-helm upgrade devportal next-charts/veecode-devportal-platform \
+helm upgrade devportal veecode-devportal-platform \
+  --repo https://veecode-platform.github.io/next-charts \
   --namespace platform \
   --reuse-values \
   --set existingSecret=my-devportal-creds

--- a/devportal/migrating-from-v1.md
+++ b/devportal/migrating-from-v1.md
@@ -177,19 +177,25 @@ Pick the path that matches V1's:
 - **Production Kubernetes** → the published `veecode-devportal-platform` Helm chart from the `next-charts` repo. This is **not** the same as installing from a local chart checkout (`helm install dp ./veecode-devportal-platform-chart`) — that path is for chart maintainers only:
 
   ```bash
-  helm repo add next-charts https://veecode-platform.github.io/next-charts
-  helm repo update next-charts
-
-  helm install devportal next-charts/veecode-devportal-platform \
+  helm install devportal veecode-devportal-platform \
+    --repo https://veecode-platform.github.io/next-charts \
     --namespace platform --create-namespace \
     --set 'presets={recommended,veecode-theme,<your-integration-presets>}' \
     --set existingSecret=my-devportal-creds
   ```
 
+  `--repo` resolves the chart straight from the URL — no `helm repo add` needed. If you'd rather have a persistent local alias (handy for repeated `helm search`/`helm show values`), add it once and use `next-charts/veecode-devportal-platform` instead of `veecode-devportal-platform --repo <url>` in any command here:
+
+  ```bash
+  helm repo add next-charts https://veecode-platform.github.io/next-charts
+  helm repo update next-charts
+  ```
+
   Once V2 is installed, later chart-version bumps are a normal `helm upgrade` — this one *is* an in-place update, unlike the V1→V2 move itself:
 
   ```bash
-  helm upgrade devportal next-charts/veecode-devportal-platform \
+  helm upgrade devportal veecode-devportal-platform \
+    --repo https://veecode-platform.github.io/next-charts \
     --namespace platform \
     --reuse-values \
     --set existingSecret=my-devportal-creds


### PR DESCRIPTION
## Summary
- Production release promoting `develop` → `main`.
- Reorders install/upgrade examples across the setup guide, migration guide, and chart README to lead with `--repo` direct instead of `helm repo add`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)