### PR TITLE
docs(devportal): stateless PostgreSQL is the default (chart 0.5.0) — to main

### DIFF
--- a/devportal/installation-guide/production-setup/plan.md
+++ b/devportal/installation-guide/production-setup/plan.md
@@ -80,17 +80,17 @@ The chart also accepts a `credentials: { KEY: value, ... }` map that renders a S
 <!-- dp-source: storage,pvc,helm -->
 ## Persistent volumes
 
-The chart provisions two PVCs by default:
+Both PVCs are **off by default** — the recommended posture is stateless on external PostgreSQL, which needs no PVC at all. Enable them only for the SQLite / single-node dev path:
 
-| Value key | Mount path | Default size | What it holds |
-|-----------|-----------|-------------|---------------|
-| `persistence.data` | `/app/data` | 1 Gi | SQLite databases (catalog cache) and marketplace state. Without this PVC the catalog is wiped on every restart. |
-| `persistence.plugins` | `/app/dynamic-plugins-root` | 2 Gi | Downloaded OCI plugin bundles. Without this, all plugins are re-fetched on every restart (~60–90 s). |
+| Value key | Default | Mount path | Size when enabled | What it holds |
+|-----------|---------|-----------|-------------------|---------------|
+| `persistence.data` | `false` | `/app/data` | 1 Gi | SQLite databases (catalog cache) and marketplace state. **Required if you run SQLite** (`database.external.enabled=false`) — without it the catalog is wiped on every restart. |
+| `persistence.plugins` | `false` | `/app/dynamic-plugins-root` | 2 Gi | Downloaded OCI plugin bundles. Purely a speed-up — with it off, plugins are re-fetched on every restart (~60–90 s). |
 
-Ensure your cluster has a `StorageClass` that supports `ReadWriteOnce`. Cloud-managed clusters (GKE, EKS, AKS) include one by default.
+If you enable `persistence.data`, ensure your cluster has a `StorageClass` that supports `ReadWriteOnce`. Cloud-managed clusters (GKE, EKS, AKS) include one by default.
 
 :::warning
-`helm uninstall` deletes the data PVC along with the release. Back up the SQLite database before uninstalling if you need to preserve the catalog state.
+When `persistence.data.enabled=true`, `helm uninstall` deletes the data PVC along with the release. Back up the SQLite database before uninstalling if you need to preserve the catalog state. (On stateless PostgreSQL there is no data PVC — the database is the durable store.)
 :::
 
 ---
@@ -98,9 +98,7 @@ Ensure your cluster has a `StorageClass` that supports `ReadWriteOnce`. Cloud-ma
 <!-- dp-source: postgres -->
 ## Database
 
-By default DevPortal uses **persistent SQLite** on the `/app/data` PVC. This is correct for single-replica deployments.
-
-For multi-replica deployments (`replicaCount > 1`), SQLite is not safe — you must switch to **external PostgreSQL**:
+By default DevPortal runs **stateless on external PostgreSQL** — the recommended posture, and required for multi-replica deployments (`replicaCount > 1`), where SQLite is not safe:
 
 ```bash
 helm install devportal next-charts/veecode-devportal-platform \
@@ -109,7 +107,9 @@ helm install devportal next-charts/veecode-devportal-platform \
   --set existingSecret=my-devportal-creds  # must contain PG_* vars
 ```
 
-The Secret must contain: `PG_HOST`, `PG_PORT`, `PG_USER`, `PG_PASSWORD`, `PG_DATABASE`. When `database.external.enabled=true` the chart does not create the data PVC (Postgres is the state store).
+The Secret must contain: `PG_HOST`, `PG_PORT`, `PG_USER`, `PG_PASSWORD`, `PG_DATABASE` (the PG user needs `CREATEDB` — Backstage creates several `backstage_plugin_*` databases). When `database.external.enabled=true` the chart creates no data PVC — Postgres is the state store.
+
+For a single-node dev cluster with no database, opt into **persistent SQLite** instead (`--set persistence.data.enabled=true`, see [Persistent volumes](#persistent-volumes) above). A render-time guard blocks a bare install that picks neither path, since SQLite on an ephemeral volume loses all state on restart.
 
 ---
 
@@ -167,7 +167,7 @@ If you enable the `kubernetes` preset, also set `rbac.clusterRoles.create=true` 
 ## Checklist before deploying
 
 - [ ] Namespace created (or `--create-namespace` passed to `helm install`)
-- [ ] StorageClass available for `ReadWriteOnce` PVCs
+- [ ] External PostgreSQL reachable with a `CREATEDB`-capable user (default posture) — **or**, for the SQLite dev path, a `StorageClass` supporting `ReadWriteOnce`
 - [ ] Kubernetes Secret created with all required variables for your preset combination
 - [ ] Preset list finalized (at most one identity preset)
 - [ ] Ingress controller installed in the cluster

--- a/devportal/installation-guide/production-setup/production-setup.md
+++ b/devportal/installation-guide/production-setup/production-setup.md
@@ -24,12 +24,12 @@ Use this guide when you need a persistent, team-accessible DevPortal instance �
 
 ## Deployment approach
 
-DevPortal V2 is distributed as the `veecode-devportal-platform` Helm chart (chart version `0.1.0`, app version `2.1.3`) published in the `next-charts` Helm repository. The chart deploys the `docker.io/veecode/devportal:2.1.3` image and manages the following resources on your behalf:
+DevPortal V2 is distributed as the `veecode-devportal-platform` Helm chart published in the `next-charts` Helm repository. The chart deploys the `docker.io/veecode/devportal` image and manages the following resources on your behalf:
 
 | Resource | Purpose |
 |----------|---------|
 | `Deployment` | Runs the DevPortal container |
-| `PersistentVolumeClaim` (×2) | Persists catalog state (`/app/data`) and plugin bundles (`/app/dynamic-plugins-root`) |
+| `PersistentVolumeClaim` (×2, opt-in) | Only when `persistence.*` is enabled for the SQLite dev path — catalog state (`/app/data`) and plugin bundles (`/app/dynamic-plugins-root`). None created in the default stateless/PostgreSQL posture |
 | `Secret` (optional) | Chart-managed credentials (dev convenience; `existingSecret` is recommended for production) |
 | `Service` | Exposes port 7007 within the cluster |
 | `Ingress` | Routes external traffic (opt-in via `ingress.enabled`) |

--- a/devportal/installation-guide/production-setup/setup.md
+++ b/devportal/installation-guide/production-setup/setup.md
@@ -116,7 +116,7 @@ For AWS RDS, prefer a Multi-AZ instance — with PVCs removed the database becom
 
 ### Production (PostgreSQL — recommended)
 
-With `database.external.enabled=true` the chart disables the internal SQLite path and injects a `backend.database` block using the `PG_*` credentials from your Secret. Remove both PVCs — the pod becomes fully stateless and schedules in any availability zone:
+This is the chart's **default** posture. `database.external.enabled=true` injects a `backend.database` block using the `PG_*` credentials from your Secret, and with both PVCs off the pod is fully stateless and schedules in any availability zone (the flags below are the defaults, shown explicitly for clarity):
 
 ```bash
 helm install devportal veecode-devportal-platform \
@@ -134,7 +134,7 @@ With stateless pods, `replicaCount > 1` is safe for steady-state traffic. Add `-
 
 ### Development / minimal (SQLite)
 
-The default path provisions two PVCs (`/app/data` and `/app/dynamic-plugins-root`). Suitable for a single-node dev cluster; an EBS- or RWO-backed PVC pins the pod to one availability zone and is not recommended for production:
+This is an **opt-in** path — the chart defaults to stateless PostgreSQL and a render-time guard **blocks a bare install** unless you pick a persistence path. Enable the two PVCs (`/app/data` and `/app/dynamic-plugins-root`) explicitly. Suitable for a single-node dev cluster only; an EBS- or RWO-backed PVC pins the pod to one availability zone and is not recommended for production:
 
 ```bash
 helm install devportal veecode-devportal-platform \
@@ -142,7 +142,9 @@ helm install devportal veecode-devportal-platform \
   --namespace platform \
   --create-namespace \
   --set 'presets={recommended,github,github-auth}' \
-  --set existingSecret=my-devportal-creds
+  --set existingSecret=my-devportal-creds \
+  --set persistence.data.enabled=true \
+  --set persistence.plugins.enabled=true
 ```
 
 ### Common options

--- a/devportal/migrating-from-v1.md
+++ b/devportal/migrating-from-v1.md
@@ -109,7 +109,7 @@ beyond setting `VEECODE_PRESETS`:
 
 3. **State volumes (SQLite path) or external PostgreSQL.** V1 ran with ephemeral storage; V2 needs a persistence decision:
 
-   - **SQLite (default):** mount two volumes so restarts don't wipe state:
+   - **SQLite (simplest — no database to run):** mount two volumes so restarts don't wipe state:
      - `/app/data` — Backstage SQLite databases plus the marketplace's `extensions-install.yaml`. Must be a **directory** volume, not a single-file bind (the marketplace rewrites the file via atomic temp-file + rename).
      - `/app/dynamic-plugins-root` — resolved plugin-bundle cache (fast restart).
    - **PostgreSQL (recommended for production):** set `backend.database.client: pg` in `app-config.local.yaml` — neither volume is required. The pod is fully stateless; a boot pre-step regenerates `extensions-install.yaml` from the database on each start.
@@ -160,7 +160,7 @@ Use this table to find where each V1 setting goes. Build the new file against
 | `upstream.backstage.image` (`veecode/devportal:1.4.5`) | `image` (`veecode/devportal:2.1.3`) |
 | `upstream.postgresql.*` (bundled Bitnami subchart) | `database.external.*` — no bundled database; supply external coordinates |
 | `createClusterRoles: true` | `rbac.clusterRoles.create: true` |
-| _(ephemeral; no PVCs)_ | `persistence.data` + `persistence.plugins` — new in V2; required for **SQLite** deployments (default), **not needed** when `database.external.enabled=true` |
+| _(ephemeral; no PVCs)_ | `persistence.data` + `persistence.plugins` — new in V2; **off by default** (stateless on external PostgreSQL, the default). Enable them only for the opt-in **SQLite** dev path (`database.external.enabled=false`) |
 
 Two deltas have no V1 equivalent and are easy to miss:
 
@@ -168,7 +168,7 @@ Two deltas have no V1 equivalent and are easy to miss:
    `appConfig` and fed them via `extraEnvVarsSecret`. In V2 the presets read
    their variables from the environment, so put them in a Secret referenced by
    `existingSecret` — see [Step 2 of the install guide](./installation-guide/production-setup/setup.md#step-2-create-the-credentials-secret).
-2. **PVCs depend on your database choice.** The V1 wrapper ran with ephemeral storage. V2 defaults to SQLite, which requires `persistence.data` (Backstage state + marketplace selections) and `persistence.plugins` (plugin-bundle cache). With external PostgreSQL (`database.external.enabled=true`) both volumes can be disabled — the pod becomes fully stateless and schedules in any availability zone. See [Deploy to Kubernetes](./installation-guide/production-setup/setup.md#step-3-install-the-chart) for the production install command.
+2. **PVCs depend on your database choice.** The V1 wrapper ran with ephemeral storage. V2 defaults to **stateless on external PostgreSQL** — no PVC, the pod schedules in any availability zone. A render-time guard blocks a bare install that picks neither path. Only the opt-in SQLite dev path (`database.external.enabled=false`) needs `persistence.data` (Backstage state + marketplace selections) and `persistence.plugins` (plugin-bundle cache). See [Deploy to Kubernetes](./installation-guide/production-setup/setup.md#step-3-install-the-chart) for the production install command.
 
 ## Installing V2
 


### PR DESCRIPTION
Promotes the docs change from #45 (already merged to `develop`) directly to `main` so the production docs site reflects chart 0.5.0's stateless-by-default posture now. Cherry-pick of the #45 squash commit — isolates this change, does not drag unrelated in-flight `develop` work into production.

Same content as #45: setup.md / plan.md / production-setup.md / migrating-from-v1.md reframed to stateless-PostgreSQL-default (PVCs opt-in), SQLite install command fixed to pass the persistence flags, guard + CREATEDB documented.

🤖 Generated with [Claude Code](https://claude.com/claude-code)